### PR TITLE
SIcon Size with Number type.

### DIFF
--- a/src/components/Icon/SIcon.vue
+++ b/src/components/Icon/SIcon.vue
@@ -42,7 +42,7 @@ export default class SIcon extends Vue {
   get computedStyles () {
     const styles = {} as any
     if (this.size) {
-      styles.fontSize = typeof this.size === 'number' ? `${this.size}px` : this.size
+      styles.fontSize = !isNaN(+this.size) ? `${this.size}px` : this.size
     }
     return styles
   }


### PR DESCRIPTION
Size prop didn't work as expected. It was a string type always and that's why we couldn't set the size in `size='16'` style.
I fixed this behaviour.