### PR TITLE
Fix broken `SInput` error state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu/soramitsu-js-ui",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": false,
   "publishConfig": {
     "registry": "https://nexus.iroha.tech/repository/npm-soramitsu/"

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -23,37 +23,17 @@
         }
       }
       > [class^="s-input"]:not(.s-disabled) {
-        .s-placeholder {
-          color: var(--s-color-status-error);
-          background-color: var(--s-color-status-error-background);
-        }
+        background-color: var(--s-color-status-error-background);
+        border-color: var(--s-color-status-error);
+
         input, textarea {
-          background-color: var(--s-color-status-error-background);
           &::placeholder {
             color: var(--s-color-status-error);
           }
         }
-        &:hover {
-          .s-placeholder,
-          .el-input > input,
-          .el-textarea > textarea {
-            background-color: var(--s-color-status-error-background);
-          }
-          .el-input > input,
-          .el-textarea > textarea {
-            border-color: var(--s-color-status-error);
-          }
-        }
+
         &.s-focused {
-          .s-placeholder,
-          .el-input > input,
-          .el-textarea > textarea {
-            background-color: var(--s-color-base-on-accent);
-          }
-          .el-input > input,
-          .el-textarea > textarea {
-            border-color: var(--s-color-status-error);
-          }
+          background-color: var(--s-color-base-on-accent);
         }
       }
     }

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -26,6 +26,10 @@
         background-color: var(--s-color-status-error-background);
         border-color: var(--s-color-status-error);
 
+        .s-placeholder {
+          color: var(--s-color-status-error);
+        }
+
         input, textarea {
           &::placeholder {
             color: var(--s-color-status-error);

--- a/src/styles/input.scss
+++ b/src/styles/input.scss
@@ -93,6 +93,10 @@ $input-padding-left: $s-basic-spacing * 2 - $input-border-width;
     }
   }
 
+  &.s-autofill {
+    background: rgb(232, 240, 254); // chrome auto-fill background
+  }
+
   &--prefix:not(.s-textarea) {
     .s-placeholder {
       padding-left: $input-icon-width + $s-basic-spacing;
@@ -171,6 +175,9 @@ $input-padding-left: $s-basic-spacing * 2 - $input-border-width;
     &:-webkit-autofill {
       color: var(--s-color-base-content-primary) !important;
       animation-name: onAutoFillStart; // Expose a hook for JavaScript when auto fill is shown
+
+      // removing user-agent background with hack
+      transition: background-color 5000s ease-in-out 0s;
     }
     &:not(:-webkit-autofill) {
       animation-name: onAutoFillCancel; // Expose a hook for JS onAutoFillCancel


### PR DESCRIPTION
### Explanation

Previously, the border and background of the entire component was set directly to the input element. Then, in the "Neumorphism. Button." commit the `SInput` component has been styled and the input element is now a small inner element with no borders and a background that does not cover the entire element, and the error state styling remains the same. This led to the following result:

![image](https://user-images.githubusercontent.com/43530070/122374335-f5aa6500-cf6a-11eb-8a03-40dda1fdbdbc.png)

### Solution

This PR fixes this problem by applying styles specifically to the container, and not to the `<input>` itself. The hover / focus behavior is the same as before.