### PR TITLE
Hotfix - workaround #433

### DIFF
--- a/.changeset/rich-dryers-nail.md
+++ b/.changeset/rich-dryers-nail.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**: (`SAccordionItem`) workaround #433 by using `modelValue` directly

--- a/packages/ui/src/components/Accordion/SAccordionItem.vue
+++ b/packages/ui/src/components/Accordion/SAccordionItem.vue
@@ -95,7 +95,7 @@ if (groupApi) {
 
     <SCollapseTransition>
       <div
-        v-show="model"
+        v-show="modelValue"
         :id="contentId"
         class="s-accordion-item__body-wrapper"
         data-testid="content"


### PR DESCRIPTION
Please follow #433 for more details.

This tiny PR introduce a hot workaround to be able to use `SAccordionItem`.

More research is needed, as well as strong reproduction and test for the future. Also maybe it will outcome into an issue in vuejs/core.