### PR TITLE
Chevron slot in SAccordionItem

### DIFF
--- a/packages/ui/src/components/Accordion/SAccordionItem.vue
+++ b/packages/ui/src/components/Accordion/SAccordionItem.vue
@@ -99,10 +99,11 @@ if (groupApi) {
           />
         </div>
       </div>
-      <IconArrowsChevronDownRounded24
-        class="s-accordion-item__chevron"
-        aria-hidden="true"
-      />
+      <div class="s-accordion-item__chevron">
+        <slot name="chevron">
+          <IconArrowsChevronDownRounded24 aria-hidden="true" />
+        </slot>
+      </div>
     </button>
 
     <SCollapseTransition>


### PR DESCRIPTION
The solution to be able to use your own icon for chevron in SAccordionItem