### PR TITLE
Fix extra attributes passing in `STextField`

### DIFF
--- a/.changeset/tall-walls-boil.md
+++ b/.changeset/tall-walls-boil.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**: (`STextField`) fix extra attributes binding

--- a/packages/ui/cypress/component/STextField.spec.cy.ts
+++ b/packages/ui/cypress/component/STextField.spec.cy.ts
@@ -321,3 +321,29 @@ it('Autofocus works', () => {
   mount({ template: `<STextField autofocus />` })
   findInput().should('have.attr', 'autofocus')
 })
+
+describe('Passing extra attributes', () => {
+  it('they are passed to <input>', () => {
+    mount({ template: `<STextField extra-attr />` })
+
+    findInput().should('have.attr', 'extra-attr')
+  })
+
+  it('they are reactive', () => {
+    mount({
+      setup() {
+        const { count, inc } = useCounter()
+        return { count, inc }
+      },
+      template: `
+        <button @click="inc()">inc</button>
+
+        <STextField :data-count="count" />
+      `,
+    })
+
+    findInput().should('have.attr', 'data-count', 0)
+    cy.get('button').contains('inc').click()
+    findInput().should('have.attr', 'data-count', 1)
+  })
+})

--- a/packages/ui/src/components/TextField/STextField.vue
+++ b/packages/ui/src/components/TextField/STextField.vue
@@ -182,10 +182,15 @@ const counterText = computed<string | null>(() => {
   return limit === null ? String(currentCount) : `${currentCount}/${limit}`
 })
 
+// attrs are not reactive: https://vuejs.org/api/composition-api-setup.html#setup-context
+// so we need to compute them directly in the render function
 const attrs = useAttrs()
-const rootClass = computed(() => attrs.class)
-const rootStyle = computed(() => attrs.style as StyleValue)
-const inputAttrs = reactiveOmit(attrs, 'class', 'style')
+const rootClass = () => attrs.class
+const rootStyle = () => attrs.style as StyleValue
+const inputAttrs = () => {
+  const { style, class: clazz, ...rest } = attrs
+  return rest
+}
 
 // APPEND
 
@@ -209,9 +214,9 @@ const inputType = computed(() =>
         's-text-field_empty': isValueEmpty,
         's-text-field_disabled': disabled,
       },
-      rootClass,
+      rootClass(),
     ]"
-    :style="rootStyle"
+    :style="rootStyle()"
     :data-status="status"
   >
     <div class="s-text-field__input-wrapper">
@@ -227,7 +232,7 @@ const inputType = computed(() =>
         :value="model"
         :type="inputType"
         :disabled="disabled"
-        v-bind="inputAttrs"
+        v-bind="inputAttrs()"
         @input="onInput"
         @focus="isFocused = true"
         @blur="isFocused = false"


### PR DESCRIPTION
Before there was an issue when extra attribute is passed:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/43530070/178105592-d30c8375-7e38-4de3-9652-979ab2614bf4.png">

Also vue documentation says that `attrs` are not reactive. But it is a mystery why it was... Anyway, not attrs are used in the correct way (I hope).