### PR TITLE
WDS-125 async select search

### DIFF
--- a/.changeset/eleven-donuts-sin.md
+++ b/.changeset/eleven-donuts-sin.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': minor
----
-
-feat(`STextField`): add `passiveAppend` prop to make append part focus input on click

--- a/.changeset/eleven-donuts-sin.md
+++ b/.changeset/eleven-donuts-sin.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+feat(`STextField`): add `passiveAppend` prop to make append part focus input on click

--- a/.changeset/nine-vans-dress.md
+++ b/.changeset/nine-vans-dress.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+feat(`STextField`): add `prefix` slot - inline elements before input and `filledState` prop to use filled state when prefix presents

--- a/.changeset/nine-vans-dress.md
+++ b/.changeset/nine-vans-dress.md
@@ -2,4 +2,5 @@
 '@soramitsu-ui/ui': minor
 ---
 
-**feat**(`STextField`): add `prefix` slot - inline elements before input and `filledState` prop to use filled state when prefix presents
+**feat**(`STextField`): add `prefix` slot to render inline elements before input, and `filled-state` prop to manually activate the filled state on the component when the prefix presents
+

--- a/.changeset/nine-vans-dress.md
+++ b/.changeset/nine-vans-dress.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': minor
 ---
 
-feat(`STextField`): add `prefix` slot - inline elements before input and `filledState` prop to use filled state when prefix presents
+**feat**(`STextField`): add `prefix` slot - inline elements before input and `filledState` prop to use filled state when prefix presents

--- a/.changeset/real-radios-repair.md
+++ b/.changeset/real-radios-repair.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': minor
 ---
 
-**feat**(`SSelect`, `SDropdown`): add empty slot for menu
+**feat**(`SSelect`, `SDropdown`): introduce `empty` slot; it is forwarded to the underlying `SSelectDropdown` component

--- a/.changeset/real-radios-repair.md
+++ b/.changeset/real-radios-repair.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+**feat**(`SSelect`, `SDropdown`): add empty slot for menu

--- a/.changeset/sixty-pants-dance.md
+++ b/.changeset/sixty-pants-dance.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+fix (`STextField`): fix input font

--- a/.changeset/sixty-pants-dance.md
+++ b/.changeset/sixty-pants-dance.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': patch
 ---
 
-fix (`STextField`): fix input font
+**fix**(`STextField`): fix input font

--- a/.changeset/sixty-pants-dance.md
+++ b/.changeset/sixty-pants-dance.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': patch
 ---
 
-**fix**(`STextField`): fix input font
+**fix**(`STextField`): specify input font (`sora-tpg-p3`)

--- a/.changeset/sweet-baboons-brush.md
+++ b/.changeset/sweet-baboons-brush.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+**feat**(`SSelect`, `SDropdown`): add `remote-search` prop that disables default search behaviour

--- a/.changeset/wild-timers-act.md
+++ b/.changeset/wild-timers-act.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+**feat**(`SSelect`): add `triggerSearch` prop to enable search input in select input

--- a/packages/ui/cypress/component/Select.spec.cy.ts
+++ b/packages/ui/cypress/component/Select.spec.cy.ts
@@ -7,7 +7,7 @@ import {
   SDropdown,
   SelectSize,
   STextField,
-  SelectOptionType
+  SelectOptionType,
 } from '@/lib'
 
 const SIZES = [SelectSize.Sm, SelectSize.Md, SelectSize.Lg, SelectSize.Xl]
@@ -417,14 +417,13 @@ it('SSelectDropdown overlaps STextField', () => {
     // trying to click to ensure the element is not covered by anything
     .click()
 })
-
 ;['SSelect', 'SDropdown'].forEach((selectVariantName) => {
   it(`${selectVariantName} - 'empty' slot works`, () => {
     cy.mount({
       setup() {
         return {
           options: [],
-          selectVariantName
+          selectVariantName,
         }
       },
       template: `
@@ -437,7 +436,7 @@ it('SSelectDropdown overlaps STextField', () => {
     })
 
     cy.get(testidSelector('select-trigger')).click()
-    cy.contains('I\'m empty').should('exist')
+    cy.contains("I'm empty").should('exist')
   })
 
   it(`${selectVariantName} - it is possible to set option type`, () => {
@@ -447,7 +446,7 @@ it('SSelectDropdown overlaps STextField', () => {
           options: [{ label: 'label', value: 'value' }],
           selectVariantName,
           selectOptionTypes: Object.values(SelectOptionType),
-          selectOptionType: ref()
+          selectOptionType: ref(),
         }
       },
       template: `
@@ -530,9 +529,7 @@ it(`SSelect - popup is same width as trigger`, () => {
   cy.mount({
     setup() {
       return {
-        options: [
-          { label: 'label11', value: 'value1' },
-        ],
+        options: [{ label: 'label11', value: 'value1' }],
         model: ref('value1'),
       }
     },

--- a/packages/ui/cypress/component/Select.spec.cy.ts
+++ b/packages/ui/cypress/component/Select.spec.cy.ts
@@ -1,5 +1,14 @@
 import { VueTestUtils } from 'cypress/vue'
-import { SSelect, SSelectBase, SSelectButton, SSelectInput, SDropdown, SelectSize, STextField } from '@/lib'
+import {
+  SSelect,
+  SSelectBase,
+  SSelectButton,
+  SSelectInput,
+  SDropdown,
+  SelectSize,
+  STextField,
+  SelectOptionType
+} from '@/lib'
 
 const SIZES = [SelectSize.Sm, SelectSize.Md, SelectSize.Lg, SelectSize.Xl]
 
@@ -14,6 +23,7 @@ after(() => {
 })
 
 const findBtnLabel = () => cy.get('.s-select-btn__label')
+const testidSelector = (id: string) => `[data-testid=${id}]`
 
 it('Gallery - Dropdown', () => {
   cy.mount({
@@ -406,4 +416,136 @@ it('SSelectDropdown overlaps STextField', () => {
   cy.contains('two')
     // trying to click to ensure the element is not covered by anything
     .click()
+})
+
+;['SSelect', 'SDropdown'].forEach((selectVariantName) => {
+  it(`${selectVariantName} - 'empty' slot works`, () => {
+    cy.mount({
+      setup() {
+        return {
+          options: [],
+          selectVariantName
+        }
+      },
+      template: `
+        <component :is="selectVariantName" v-bind="{ options }">
+          <template #empty>
+            <div>I'm empty</div>
+          </template>
+        </component>
+      `,
+    })
+
+    cy.get(testidSelector('select-trigger')).click()
+    cy.contains('I\'m empty').should('exist')
+  })
+
+  it(`${selectVariantName} - it is possible to set option type`, () => {
+    cy.mount({
+      setup() {
+        return {
+          options: [{ label: 'label', value: 'value' }],
+          selectVariantName,
+          selectOptionTypes: Object.values(SelectOptionType),
+          selectOptionType: ref()
+        }
+      },
+      template: `
+        <select id="options-type" v-model="selectOptionType">
+          <option v-for="type in selectOptionTypes" :value="type" />
+        </select>
+
+        <component :is="selectVariantName" v-bind="{ options }" model-value="value" :option-type="selectOptionType"/>
+      `,
+    })
+
+    cy.get('select#options-type').select(SelectOptionType.Default)
+    cy.get(testidSelector('select-trigger')).click()
+    cy.get(testidSelector('select-option-checkmark')).should('exist')
+
+    cy.get('select#options-type').select(SelectOptionType.Radio)
+    cy.get(testidSelector('select-trigger')).click()
+    cy.get(testidSelector('select-option-radio')).should('exist')
+
+    cy.get('select#options-type').select(SelectOptionType.Checkbox)
+    cy.get(testidSelector('select-trigger')).click()
+    cy.get(testidSelector('select-option-checkbox')).should('exist')
+  })
+
+  it(`${selectVariantName} - there are dropdown search that allows filter options by labels`, () => {
+    cy.mount({
+      setup() {
+        return {
+          options: [
+            { label: 'label11', value: 'value1' },
+            { label: 'label112', value: 'value2' },
+            { label: 'label133', value: 'value3' },
+            { label: 'label13', value: 'value4' },
+          ],
+          model: ref('value1'),
+          selectVariantName,
+        }
+      },
+      template: `
+        <component :is="selectVariantName" v-bind="{ options }" model-value="value" dropdown-search />
+      `,
+    })
+
+    const SEARCH_QUERY = 'label11'
+    const OPTIONS_WITH_SEARCH_QUERY_IN_LABEL = 2
+
+    cy.get(testidSelector('select-trigger')).click()
+    cy.get(testidSelector('select-dropdown-search')).type(SEARCH_QUERY)
+    cy.get(testidSelector('select-option')).should('have.length', OPTIONS_WITH_SEARCH_QUERY_IN_LABEL)
+  })
+})
+
+it(`SSelect - there are trigger search that allows filter options by labels`, () => {
+  cy.mount({
+    setup() {
+      return {
+        options: [
+          { label: 'label11', value: 'value1' },
+          { label: 'label112', value: 'value2' },
+          { label: 'label133', value: 'value3' },
+          { label: 'label13', value: 'value4' },
+        ],
+        model: ref('value1'),
+      }
+    },
+    template: `
+        <SSelect v-bind="{ options }" trigger-search />
+      `,
+  })
+
+  const SEARCH_QUERY = 'label11'
+  const OPTIONS_WITH_SEARCH_QUERY_IN_LABEL = 2
+
+  cy.get(testidSelector('select-trigger')).click()
+  cy.get(testidSelector('select-trigger')).type(SEARCH_QUERY)
+  cy.get(testidSelector('select-option')).should('have.length', OPTIONS_WITH_SEARCH_QUERY_IN_LABEL)
+})
+
+it(`SSelect - popup is same width as trigger`, () => {
+  cy.mount({
+    setup() {
+      return {
+        options: [
+          { label: 'label11', value: 'value1' },
+        ],
+        model: ref('value1'),
+      }
+    },
+    template: `
+        <SSelect v-bind="{ options }" />
+      `,
+  })
+
+  cy.get(testidSelector('select-trigger')).click()
+
+  cy.get(testidSelector('select-trigger')).then(($el1) => {
+    cy.get(testidSelector('select-dropdown')).should(($el2) => {
+      expect($el2).to.have.css('width', $el1.outerWidth() + 'px')
+    })
+  })
 })

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -367,7 +367,7 @@ showCloseBtn: boolean;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SBadge: DefineComponent<__VLS_WithDefaults_18<__VLS_TypePropsToRuntimeProps_21<{
+export const SBadge: DefineComponent<__VLS_WithDefaults_19<__VLS_TypePropsToRuntimeProps_22<{
 type?: "info" | "warning" | "error" | "active" | "debug" | "pending" | undefined;
 colorBackground?: boolean | undefined;
 withBorder?: boolean | undefined;
@@ -377,7 +377,7 @@ type: string;
 colorBackground: boolean;
 withBorder: boolean;
 onlyMarker: boolean;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_18<__VLS_TypePropsToRuntimeProps_21<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_19<__VLS_TypePropsToRuntimeProps_22<{
 type?: "info" | "warning" | "error" | "active" | "debug" | "pending" | undefined;
 colorBackground?: boolean | undefined;
 withBorder?: boolean | undefined;
@@ -475,11 +475,11 @@ export const SCheckboxAtom: FunctionalComponent<Props_8>;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SCheckboxSolo: DefineComponent<__VLS_WithDefaults_19<__VLS_TypePropsToRuntimeProps_22<Props_9>, {
+export const SCheckboxSolo: DefineComponent<__VLS_WithDefaults_20<__VLS_TypePropsToRuntimeProps_23<Props_9>, {
 modelValue: boolean;
 type: string;
 size: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_19<__VLS_TypePropsToRuntimeProps_22<Props_9>, {
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_20<__VLS_TypePropsToRuntimeProps_23<Props_9>, {
 modelValue: boolean;
 type: string;
 size: string;
@@ -495,11 +495,11 @@ size: "md" | "lg" | "xl";
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SCollapseTransition: DefineComponent<__VLS_WithDefaults_20<__VLS_TypePropsToRuntimeProps_23<{
+export const SCollapseTransition: DefineComponent<__VLS_WithDefaults_21<__VLS_TypePropsToRuntimeProps_24<{
 duration?: string | undefined;
 }>, {
 duration: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_20<__VLS_TypePropsToRuntimeProps_23<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_21<__VLS_TypePropsToRuntimeProps_24<{
 duration?: string | undefined;
 }>, {
 duration: string;
@@ -512,12 +512,12 @@ duration: string;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SDatePicker: DefineComponent<__VLS_WithDefaults_14<__VLS_TypePropsToRuntimeProps_17<Props_7>, {
+export const SDatePicker: DefineComponent<__VLS_WithDefaults_15<__VLS_TypePropsToRuntimeProps_18<Props_7>, {
 type: string;
 time: boolean;
 disabled: boolean;
 shortcuts: () => DatePickerOptions;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_14<__VLS_TypePropsToRuntimeProps_17<Props_7>, {
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_15<__VLS_TypePropsToRuntimeProps_18<Props_7>, {
 type: string;
 time: boolean;
 disabled: boolean;
@@ -546,6 +546,7 @@ inline?: boolean | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_TypePropsToRuntimeProps_10<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -558,6 +559,7 @@ inline?: boolean | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>>>, {}>;
 
 // @public (undocumented)
@@ -582,6 +584,8 @@ export interface SelectApi<T> extends UnwrapRef<UseSelectModelReturn<T>> {
     readonly noAutoClose: boolean;
     // (undocumented)
     readonly options: UnwrapRef<SelectOption<T>[] | SelectOptionGroup<T>[]>;
+    // (undocumented)
+    readonly remoteSearch: boolean;
     // (undocumented)
     readonly searchQuery: string;
     // (undocumented)
@@ -770,7 +774,7 @@ close: boolean;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SNavigationMenu: DefineComponent<__VLS_WithDefaults_24<__VLS_TypePropsToRuntimeProps_27<{
+export const SNavigationMenu: DefineComponent<__VLS_WithDefaults_25<__VLS_TypePropsToRuntimeProps_28<{
 modelValue?: string | undefined;
 collapsed?: boolean | undefined;
 }>, {
@@ -778,7 +782,7 @@ modelValue: string;
 collapsed: boolean;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "update:modelValue": (value: string) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_24<__VLS_TypePropsToRuntimeProps_27<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_25<__VLS_TypePropsToRuntimeProps_28<{
 modelValue?: string | undefined;
 collapsed?: boolean | undefined;
 }>, {
@@ -795,9 +799,9 @@ collapsed: boolean;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SNavigationMenuItem: DefineComponent<__VLS_WithDefaults_23<__VLS_TypePropsToRuntimeProps_26<{
+export const SNavigationMenuItem: DefineComponent<__VLS_WithDefaults_24<__VLS_TypePropsToRuntimeProps_27<{
 value: string;
-}>, {}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_23<__VLS_TypePropsToRuntimeProps_26<{
+}>, {}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_24<__VLS_TypePropsToRuntimeProps_27<{
 value: string;
 }>, {}>>>, {}>;
 
@@ -846,7 +850,7 @@ export const SNotificationsProvider: FunctionalComponent<{
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SPagination: DefineComponent<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
+export const SPagination: DefineComponent<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
 total?: number | undefined;
 pageSize?: number | null | undefined;
 currentPage?: number | undefined;
@@ -866,7 +870,7 @@ sizesLabel: string;
 "update:currentPage": (value: number) => void;
 } & {
 "update:pageSize": (value: number) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
 total?: number | undefined;
 pageSize?: number | null | undefined;
 currentPage?: number | undefined;
@@ -1003,13 +1007,13 @@ innerWrapperAttrs: Record<string, any>;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SProgressBar: DefineComponent<__VLS_WithDefaults_15<__VLS_TypePropsToRuntimeProps_18<{
+export const SProgressBar: DefineComponent<__VLS_WithDefaults_16<__VLS_TypePropsToRuntimeProps_19<{
 percent?: number | undefined;
 lineHeight?: number | undefined;
 }>, {
 percent: number;
 lineHeight: number;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_15<__VLS_TypePropsToRuntimeProps_18<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_16<__VLS_TypePropsToRuntimeProps_19<{
 percent?: number | undefined;
 lineHeight?: number | undefined;
 }>, {
@@ -1025,11 +1029,11 @@ percent: number;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SRadio: DefineComponent<__VLS_WithDefaults_21<__VLS_TypePropsToRuntimeProps_24<Props_10>, {
+export const SRadio: DefineComponent<__VLS_WithDefaults_22<__VLS_TypePropsToRuntimeProps_25<Props_10>, {
 disabled: boolean;
 type: string;
 size: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_21<__VLS_TypePropsToRuntimeProps_24<Props_10>, {
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_22<__VLS_TypePropsToRuntimeProps_25<Props_10>, {
 disabled: boolean;
 type: string;
 size: string;
@@ -1049,12 +1053,12 @@ export const SRadioAtom: FunctionalComponent<Props_12>;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SRadioGroup: DefineComponent<__VLS_WithDefaults_22<__VLS_TypePropsToRuntimeProps_25<Props_11>, {
+export const SRadioGroup: DefineComponent<__VLS_WithDefaults_23<__VLS_TypePropsToRuntimeProps_26<Props_11>, {
 modelValue: null;
 radioSelector: string;
 labelledBy: string;
 describedBy: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_22<__VLS_TypePropsToRuntimeProps_25<Props_11>, {
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_23<__VLS_TypePropsToRuntimeProps_26<Props_11>, {
 modelValue: null;
 radioSelector: string;
 labelledBy: string;
@@ -1081,7 +1085,9 @@ label?: string | undefined;
 size?: SelectSize | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
+triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_TypePropsToRuntimeProps_9<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -1092,7 +1098,9 @@ label?: string | undefined;
 size?: SelectSize | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
+triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>>>, {}>;
 
 // Warning: (ae-forgotten-export) The symbol "__VLS_WithDefaults" needs to be exported by the entry point lib.d.ts
@@ -1111,7 +1119,9 @@ syncMenuAndInputWidths?: boolean | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 sameWidthPopper?: boolean | undefined;
-dropdownSearch: boolean;
+triggerSearch?: boolean | undefined;
+dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>, {
 size: "md";
 options: () => never[];
@@ -1123,7 +1133,9 @@ noAutoClose: boolean;
 label: null;
 loading: boolean;
 sameWidthPopper: boolean;
+triggerSearch: boolean;
 dropdownSearch: boolean;
+remoteSearch: boolean;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "update:modelValue": (value: any) => void;
 } & {
@@ -1140,7 +1152,9 @@ syncMenuAndInputWidths?: boolean | undefined;
 noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 sameWidthPopper?: boolean | undefined;
-dropdownSearch: boolean;
+triggerSearch?: boolean | undefined;
+dropdownSearch?: boolean | undefined;
+remoteSearch?: boolean | undefined;
 }>, {
 size: "md";
 options: () => never[];
@@ -1152,7 +1166,9 @@ noAutoClose: boolean;
 label: null;
 loading: boolean;
 sameWidthPopper: boolean;
+triggerSearch: boolean;
 dropdownSearch: boolean;
+remoteSearch: boolean;
 }>>> & {
 "onUpdate:modelValue"?: ((value: any) => any) | undefined;
 onSearch?: ((value: string) => any) | undefined;
@@ -1166,8 +1182,10 @@ options: SelectOption[] | SelectOptionGroup[];
 label: string | null;
 noAutoClose: boolean;
 dropdownSearch: boolean;
+remoteSearch: boolean;
 syncMenuAndInputWidths: boolean;
 sameWidthPopper: boolean;
+triggerSearch: boolean;
 }>;
 
 // Warning: (ae-forgotten-export) The symbol "__VLS_WithDefaults" needs to be exported by the entry point lib.d.ts
@@ -1191,18 +1209,31 @@ type: SelectButtonType;
 // @public (undocumented)
 export const SSelectChevron: FunctionalComponent<Props_3>;
 
+// Warning: (ae-forgotten-export) The symbol "__VLS_WithDefaults" needs to be exported by the entry point lib.d.ts
+// Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
+//
 // @public (undocumented)
-export const SSelectInput: DefineComponent<    {}, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, EmitsOptions, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<    {}>>, {}>;
+export const SSelectInput: DefineComponent<__VLS_WithDefaults_11<__VLS_TypePropsToRuntimeProps_13<{
+search?: boolean | undefined;
+}>, {
+search: boolean;
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_11<__VLS_TypePropsToRuntimeProps_13<{
+search?: boolean | undefined;
+}>, {
+search: boolean;
+}>>>, {
+search: boolean;
+}>;
 
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SSelectOption: DefineComponent<__VLS_TypePropsToRuntimeProps_13<{
+export const SSelectOption: DefineComponent<__VLS_TypePropsToRuntimeProps_14<{
 type: SelectOptionType;
 selected?: boolean | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 toggle: () => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_TypePropsToRuntimeProps_13<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_TypePropsToRuntimeProps_14<{
 type: SelectOptionType;
 selected?: boolean | undefined;
 }>>> & {
@@ -1214,10 +1245,10 @@ onToggle?: (() => any) | undefined;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SSpinner: DefineComponent<__VLS_WithDefaults_11<__VLS_TypePropsToRuntimeProps_14<Props_4>, {
+export const SSpinner: DefineComponent<__VLS_WithDefaults_12<__VLS_TypePropsToRuntimeProps_15<Props_4>, {
 size: string;
 width: number;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_11<__VLS_TypePropsToRuntimeProps_14<Props_4>, {
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_12<__VLS_TypePropsToRuntimeProps_15<Props_4>, {
 size: string;
 width: number;
 }>>>, {
@@ -1230,12 +1261,12 @@ width: string | number;
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SSwitch: DefineComponent<__VLS_WithDefaults_12<__VLS_TypePropsToRuntimeProps_15<Props_5>, {
+export const SSwitch: DefineComponent<__VLS_WithDefaults_13<__VLS_TypePropsToRuntimeProps_16<Props_5>, {
 label: string;
 disabled: boolean;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "update:modelValue": (value: boolean) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_12<__VLS_TypePropsToRuntimeProps_15<Props_5>, {
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_13<__VLS_TypePropsToRuntimeProps_16<Props_5>, {
 label: string;
 disabled: boolean;
 }>>> & {
@@ -1249,12 +1280,12 @@ label: string;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STab: DefineComponent<__VLS_WithDefaults_17<__VLS_TypePropsToRuntimeProps_20<{
+export const STab: DefineComponent<__VLS_WithDefaults_18<__VLS_TypePropsToRuntimeProps_21<{
 disabled?: boolean | undefined;
 name: string;
 }>, {
 disabled: boolean;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_17<__VLS_TypePropsToRuntimeProps_20<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, Record<string, any>, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_18<__VLS_TypePropsToRuntimeProps_21<{
 disabled?: boolean | undefined;
 name: string;
 }>, {
@@ -1267,7 +1298,7 @@ disabled: boolean;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STable: DefineComponent<__VLS_WithDefaults_25<__VLS_TypePropsToRuntimeProps_28<{
+export const STable: DefineComponent<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
 data?: TableRow[] | undefined;
 defaultSort?: {
 prop: string;
@@ -1361,7 +1392,7 @@ select: (payload_0: TableRow[], payload_1: TableRow) => void;
 "change:current": (payload_0: TableRow | null, payload_1: TableRow | null) => void;
 } & {
 "click:row-details": (value: TableRow) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_25<__VLS_TypePropsToRuntimeProps_28<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
 data?: TableRow[] | undefined;
 defaultSort?: {
 prop: string;
@@ -1605,6 +1636,7 @@ type: "default" | "details" | "selection" | "expand";
 width: string;
 minWidth: string;
 label: string;
+className: string;
 sortable: boolean | "custom";
 selectable: TableColumnRowSelectableFunc_2;
 prop: string;
@@ -1615,7 +1647,6 @@ formatter: TableColumnCellValueFormatter_2;
 showOverflowTooltip: boolean;
 align: "left" | "right" | "center";
 headerAlign: "left" | "right" | "center" | null;
-className: string;
 labelClassName: string;
 reserveSelection: boolean;
 }>;
@@ -1624,13 +1655,13 @@ reserveSelection: boolean;
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STabsPanel: DefineComponent<__VLS_WithDefaults_16<__VLS_TypePropsToRuntimeProps_19<{
+export const STabsPanel: DefineComponent<__VLS_WithDefaults_17<__VLS_TypePropsToRuntimeProps_20<{
 modelValue: string;
 background?: "primary" | "secondary" | "none" | undefined;
 }>, {
 modelValue: string;
 background: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_16<__VLS_TypePropsToRuntimeProps_19<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, "update:modelValue"[], "update:modelValue", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_17<__VLS_TypePropsToRuntimeProps_20<{
 modelValue: string;
 background?: "primary" | "secondary" | "none" | undefined;
 }>, {
@@ -1669,22 +1700,26 @@ export type Status = typeof Status[keyof typeof Status];
 // Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STextField: DefineComponent<__VLS_WithDefaults_13<__VLS_TypePropsToRuntimeProps_16<Props_6>, {
+export const STextField: DefineComponent<__VLS_WithDefaults_14<__VLS_TypePropsToRuntimeProps_17<Props_6>, {
 multiline: boolean;
 password: boolean;
 disabled: boolean;
 counter: boolean;
 noEye: boolean;
 noModelValueStrictSync: boolean;
+filledState: boolean;
+passiveAppend: boolean;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "update:modelValue": (value: string) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_13<__VLS_TypePropsToRuntimeProps_16<Props_6>, {
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_14<__VLS_TypePropsToRuntimeProps_17<Props_6>, {
 multiline: boolean;
 password: boolean;
 disabled: boolean;
 counter: boolean;
 noEye: boolean;
 noModelValueStrictSync: boolean;
+filledState: boolean;
+passiveAppend: boolean;
 }>>> & {
 "onUpdate:modelValue"?: ((value: string) => any) | undefined;
 }, {
@@ -1693,6 +1728,8 @@ noModelValueStrictSync: boolean;
 password: boolean;
 noEye: boolean;
 counter: string | number | boolean;
+filledState: boolean;
+passiveAppend: boolean;
 }>;
 
 // @public (undocumented)
@@ -1765,7 +1802,7 @@ apiKey: ProvideKey | ProvideKey[];
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STooltip: DefineComponent<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
+export const STooltip: DefineComponent<__VLS_WithDefaults_28<__VLS_TypePropsToRuntimeProps_31<{
 wrapperTag?: string | object | undefined;
 content?: string | undefined;
 header?: string | undefined;
@@ -1779,7 +1816,7 @@ header: string;
 placement: string;
 primaryButtonText: string;
 secondaryButtonText: string;
-}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, ("click:primary-button" | "click:secondary-button")[], "click:primary-button" | "click:secondary-button", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
+}>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, ("click:primary-button" | "click:secondary-button")[], "click:primary-button" | "click:secondary-button", VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_28<__VLS_TypePropsToRuntimeProps_31<{
 wrapperTag?: string | object | undefined;
 content?: string | undefined;
 header?: string | undefined;

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -1708,9 +1708,10 @@ counter: boolean;
 noEye: boolean;
 noModelValueStrictSync: boolean;
 filledState: boolean;
-passiveAppend: boolean;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "update:modelValue": (value: string) => void;
+} & {
+"click:input-wrapper": (value: MouseEvent) => void;
 }, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<ExtractPropTypes<__VLS_WithDefaults_14<__VLS_TypePropsToRuntimeProps_17<Props_6>, {
 multiline: boolean;
 password: boolean;
@@ -1719,9 +1720,9 @@ counter: boolean;
 noEye: boolean;
 noModelValueStrictSync: boolean;
 filledState: boolean;
-passiveAppend: boolean;
 }>>> & {
 "onUpdate:modelValue"?: ((value: string) => any) | undefined;
+"onClick:input-wrapper"?: ((value: MouseEvent) => any) | undefined;
 }, {
 disabled: boolean;
 noModelValueStrictSync: boolean;
@@ -1729,7 +1730,6 @@ password: boolean;
 noEye: boolean;
 counter: string | number | boolean;
 filledState: boolean;
-passiveAppend: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/ui/src/components/Popover/SPopover.ts
+++ b/packages/ui/src/components/Popover/SPopover.ts
@@ -190,7 +190,7 @@ export default /* @__PURE__ */ defineComponent({
     const { hover: popperHover, listeners: popperHoverListeners } = useElHover(popperRef)
     const sharedHover = or(triggerHover, popperHover)
 
-    useResizeObserver(triggerRawRef, () => {
+    useResizeObserver(triggerRef , () => {
       instance.value?.update()
     })
 

--- a/packages/ui/src/components/Popover/SPopover.ts
+++ b/packages/ui/src/components/Popover/SPopover.ts
@@ -190,6 +190,10 @@ export default /* @__PURE__ */ defineComponent({
     const { hover: popperHover, listeners: popperHoverListeners } = useElHover(popperRef)
     const sharedHover = or(triggerHover, popperHover)
 
+    useResizeObserver(triggerRawRef, () => {
+      instance.value?.update()
+    })
+
     debouncedWatch(
       () => props.trigger === 'hover' && [sharedHover.value],
       (maybeHover) => {

--- a/packages/ui/src/components/Popover/SPopover.ts
+++ b/packages/ui/src/components/Popover/SPopover.ts
@@ -190,7 +190,7 @@ export default /* @__PURE__ */ defineComponent({
     const { hover: popperHover, listeners: popperHoverListeners } = useElHover(popperRef)
     const sharedHover = or(triggerHover, popperHover)
 
-    useResizeObserver(triggerRef , () => {
+    useResizeObserver(triggerRef, () => {
       instance.value?.update()
     })
 

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -46,9 +46,9 @@ function isThereLabelSlot() {
       </SSelectButton>
     </template>
 
-    <template #dropdown>
+    <template #dropdown="{ search }">
       <SSelectDropdown
-        :search="!!dropdownSearch"
+        :search="search"
         :item-type="optionType ?? SelectOptionType.Default"
       />
     </template>

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -50,7 +50,11 @@ function isThereLabelSlot() {
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? SelectOptionType.Default"
-      />
+      >
+        <template #empty>
+          <slot name="empty" />
+        </template>
+      </SSelectDropdown>
     </template>
   </SSelectBase>
 </template>

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -16,6 +16,7 @@ const props = defineProps<{
   noAutoClose?: boolean
   loading?: boolean
   dropdownSearch?: boolean
+  remoteSearch?: boolean
 }>()
 
 const buttonType = computed(() => (props.inline ? SelectButtonType.Inline : SelectButtonType.Default))

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -31,7 +31,10 @@ function isThereLabelSlot() {
 <template>
   <SSelectBase v-bind="{ ...$attrs, ...$props } as any">
     <template #control>
-      <SSelectButton :type="buttonType">
+      <SSelectButton
+        data-testid="select-trigger"
+        :type="buttonType"
+      >
         <template
           v-if="isThereLabelSlot() || label"
           #label="binding"

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   size?: SelectSize
   noAutoClose?: boolean
   loading?: boolean
+  triggerSearch?: boolean
   dropdownSearch?: boolean
   remoteSearch?: boolean
 }>()
@@ -26,8 +27,8 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
     v-bind="{ ...$attrs, ...$props } as any"
     same-width-popper
   >
-    <template #control>
-      <SSelectInput>
+    <template #control="{ search }">
+      <SSelectInput :search="search">
         <template #label="binding">
           <slot
             name="label"

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -28,7 +28,10 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
     same-width-popper
   >
     <template #control="{ search }">
-      <SSelectInput :search="search">
+      <SSelectInput
+        data-testid="select-trigger"
+        :search="search"
+      >
         <template #label="binding">
           <slot
             name="label"

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -39,9 +39,9 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
       </SSelectInput>
     </template>
 
-    <template #dropdown>
+    <template #dropdown="{ search }">
       <SSelectDropdown
-        :search="!!dropdownSearch"
+        :search="search"
         :item-type="optionType ?? defaultOptionType"
       />
     </template>

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -43,7 +43,11 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? defaultOptionType"
-      />
+      >
+        <template #empty>
+          <slot name="empty" />
+        </template>
+      </SSelectDropdown>
     </template>
   </SSelectBase>
 </template>

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   noAutoClose?: boolean
   loading?: boolean
   dropdownSearch?: boolean
+  remoteSearch?: boolean
 }>()
 
 const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Checkbox : SelectOptionType.Radio))

--- a/packages/ui/src/components/Select/SSelectBase.vue
+++ b/packages/ui/src/components/Select/SSelectBase.vue
@@ -53,17 +53,17 @@ const props = withDefaults(
     sameWidthPopper?: boolean
 
     /**
-     * Adds search field to trigger
+     * When enabled, passes `search: true` to the `trigger` slot
      */
     triggerSearch?: boolean
 
     /**
-     * Adds search field to dropdown
+     * When enabled, passes `search: true` to the `dropdown` slot
      */
     dropdownSearch?: boolean
 
     /**
-     * Turns off options filtering by select itself. When false select filters by option's label. Adds chips
+     * By default, the component filters options by their labels. Set `true` to disable automatic filtering.
      */
     remoteSearch?: boolean
   }>(),

--- a/packages/ui/src/components/Select/SSelectBase.vue
+++ b/packages/ui/src/components/Select/SSelectBase.vue
@@ -53,6 +53,11 @@ const props = withDefaults(
     sameWidthPopper?: boolean
 
     /**
+     * Adds search field to trigger
+     */
+    triggerSearch?: boolean
+
+    /**
      * Adds search field to dropdown
      */
     dropdownSearch?: boolean
@@ -73,6 +78,7 @@ const props = withDefaults(
     label: null,
     loading: false,
     sameWidthPopper: false,
+    triggerSearch: false,
     dropdownSearch: false,
     remoteSearch: false,
   },
@@ -101,7 +107,7 @@ const [showPopper, togglePopper] = useToggle(false)
 whenever(and(disabled, showPopper), () => togglePopper(false), { immediate: true })
 
 const searchQuery = ref('')
-whenever(not(showPopper), () => {
+whenever(and(not(showPopper), not(remoteSearch)), () => {
   searchQuery.value = ''
 })
 
@@ -142,7 +148,10 @@ provide(SELECT_API_KEY, api)
     >
       <template #trigger>
         <div>
-          <slot name="control" />
+          <slot
+            name="control"
+            v-bind="{ 'search': triggerSearch }"
+          />
         </div>
       </template>
 

--- a/packages/ui/src/components/Select/SSelectBase.vue
+++ b/packages/ui/src/components/Select/SSelectBase.vue
@@ -153,7 +153,10 @@ provide(SELECT_API_KEY, api)
           :wrapper-attrs="{ 'class': 'z-10' }"
           :inner-wrapper-attrs="{ 'class': { 'w-full': sameWidthPopper } }"
         >
-          <slot name="dropdown" />
+          <slot
+            name="dropdown"
+            v-bind="{ 'search': dropdownSearch }"
+          />
         </SPopoverWrappedTransition>
       </template>
     </SPopover>

--- a/packages/ui/src/components/Select/SSelectBase.vue
+++ b/packages/ui/src/components/Select/SSelectBase.vue
@@ -55,7 +55,12 @@ const props = withDefaults(
     /**
      * Adds search field to dropdown
      */
-    dropdownSearch: boolean
+    dropdownSearch?: boolean
+
+    /**
+     * Turns off options filtering by select itself. When false select filters by option's label. Adds chips
+     */
+    remoteSearch?: boolean
   }>(),
   {
     size: SelectSize.Md,
@@ -69,6 +74,7 @@ const props = withDefaults(
     loading: false,
     sameWidthPopper: false,
     dropdownSearch: false,
+    remoteSearch: false,
   },
 )
 
@@ -78,12 +84,13 @@ const emit = defineEmits<{
 }>()
 
 const model = useVModel(props, 'modelValue', emit)
-const { multiple, disabled, loading, options, size, label, noAutoClose } = toRefs(props)
+const { multiple, disabled, loading, options, size, label, noAutoClose, remoteSearch } = toRefs(props)
 
 const modeling = useSelectModel({
   model,
   multiple,
   options,
+  storeSelectedOptions: remoteSearch,
   singleModeAutoClose: not(noAutoClose),
   onAutoClose: () => togglePopper(false),
 })
@@ -116,6 +123,7 @@ const api: SelectApi<any> = reactive({
   size,
   noAutoClose,
   searchQuery,
+  remoteSearch,
   updateSearchQuery,
 })
 

--- a/packages/ui/src/components/Select/SSelectButton.vue
+++ b/packages/ui/src/components/Select/SSelectButton.vue
@@ -52,7 +52,7 @@ const slots = useSlots()
       typography(),
       {
         's-select-btn_empty': !api.isSomethingSelected,
-        's-select-btn_disabled': api.disabled || api.loading,
+        's-select-btn_disabled': api.disabled,
       },
     ]"
     @click="toggle"

--- a/packages/ui/src/components/Select/SSelectChevron.scss
+++ b/packages/ui/src/components/Select/SSelectChevron.scss
@@ -1,5 +1,6 @@
 .s-select-chevron {
   transition: transform 0.15s;
+  fill: currentColor;
   @apply ease-in-out;
 
   &_rotate {

--- a/packages/ui/src/components/Select/SSelectChevron.ts
+++ b/packages/ui/src/components/Select/SSelectChevron.ts
@@ -3,7 +3,7 @@ import { IconChevronBottom16, IconArrowsChevronBottom24 } from '@/components/ico
 import './SSelectChevron.scss'
 
 interface Props {
-  rotate?: boolean,
+  rotate?: boolean
   variant?: 16 | 24
 }
 
@@ -21,7 +21,7 @@ const component: FunctionalComponent<Props> = ({ rotate, variant }) =>
 
 component.props = {
   rotate: Boolean,
-  variant: Number as PropType<16 | 24>
+  variant: Number as PropType<16 | 24>,
 }
 component.displayName = 'SSelectChevron'
 

--- a/packages/ui/src/components/Select/SSelectChevron.ts
+++ b/packages/ui/src/components/Select/SSelectChevron.ts
@@ -1,22 +1,28 @@
-import { FunctionalComponent, h } from 'vue'
-import IconChevronBottom from '~icons/mdi/chevron-down'
+import { FunctionalComponent, h, PropType } from 'vue'
+import { IconChevronBottom16, IconArrowsChevronBottom24 } from '@/components/icons'
 import './SSelectChevron.scss'
 
 interface Props {
-  rotate?: boolean
+  rotate?: boolean,
+  variant?: 16 | 24
 }
 
-const component: FunctionalComponent<Props> = ({ rotate }) =>
-  h(IconChevronBottom, {
+const component: FunctionalComponent<Props> = ({ rotate, variant }) =>
+  h(variant === 24 ? IconArrowsChevronBottom24 : IconChevronBottom16, {
     class: [
       's-select-chevron',
       {
         's-select-chevron_rotate': rotate,
       },
     ],
+    width: '1em',
+    height: '1em',
   })
 
-component.props = { rotate: Boolean }
+component.props = {
+  rotate: Boolean,
+  variant: Number as PropType<16 | 24>
+}
 component.displayName = 'SSelectChevron'
 
 export default component

--- a/packages/ui/src/components/Select/SSelectChip.vue
+++ b/packages/ui/src/components/Select/SSelectChip.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { IconClose } from '@/components/icons'
+
+withDefaults(
+  defineProps<{
+    label?: string
+  }>(),
+  {
+    label: '',
+  },
+)
+
+const emit = defineEmits<(event: 'click:delete') => void>()
+</script>
+
+<template>
+  <span class="s-select-chip inline-flex items-center px-6px">
+    <span class="truncate">
+      {{ label }}
+    </span>
+
+    <button
+      class="flex-shrink-0 ml-4px"
+      tabindex="-1"
+      @click.stop="emit('click:delete')"
+    >
+      <IconClose
+        width="16"
+        height="16"
+      />
+    </button>
+  </span>
+</template>
+
+<style lang="scss">
+@use '@/theme';
+
+.s-select-chip {
+  background: theme.token-as-var('sys.color.background');
+}
+</style>

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -61,9 +61,7 @@ function handleMouseDown(event: Event) {
     return
   }
 
-  if (api.multiple && !api.noAutoClose) {
-    event.preventDefault()
-  }
+  event.preventDefault()
 }
 
 const HEADER_FONT = {

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -30,7 +30,7 @@ const optionGroups: ComputedRef<SelectOptionGroup[]> = computed(() => {
 const isSearching = eagerComputed(() => props.search && api.searchQuery)
 
 const shownOptionGroups: ComputedRef<SelectOptionGroup[]> = computed(() => {
-  if (!api.searchQuery) {
+  if (!api.searchQuery || api.remoteSearch) {
     return optionGroups.value
   }
 

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -90,11 +90,13 @@ const SEARCH_ICON_SIZE = {
   <div
     class="s-select-dropdown"
     :class="`s-select-dropdown_size_${api.size}`"
+    data-testid="select-dropdown"
     @mousedown="handleMouseDown"
   >
     <div
       v-if="search"
       class="s-select-dropdown__search flex items-center"
+      data-testid="select-dropdown-search"
     >
       <IconBasicSearch24
         class="s-select-dropdown__search-icon flex-shrink-0 mr-8px"

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -7,6 +7,7 @@ import { isSelectOptions } from '@/components/Select/utils'
 import SSpinner from '@/components/Spinner/SSpinner.vue'
 import { IconBasicSearch24 } from '@/components/icons'
 import escapeStringRegexp from 'escape-string-regexp'
+import { MaybeElementRef } from '@vueuse/core'
 
 const props = defineProps<{
   itemType: SelectOptionType
@@ -27,7 +28,7 @@ const optionGroups: ComputedRef<SelectOptionGroup[]> = computed(() => {
   return options
 })
 
-const isSearching = eagerComputed(() => props.search && api.searchQuery)
+const isSearching = eagerComputed(() => api.searchQuery)
 
 const escapedQuery = computed(() => new RegExp(escapeStringRegexp(api.searchQuery), 'i'))
 const shownOptionGroups: ComputedRef<SelectOptionGroup[]> = computed(() => {
@@ -50,6 +51,18 @@ function isHeaderShown(optionGroup: SelectOptionGroup) {
 function handleSearchInput(event: Event) {
   if (event.target instanceof HTMLInputElement) {
     api.updateSearchQuery(event.target.value)
+  }
+}
+
+const searchInputRef = ref<MaybeElementRef>(null)
+
+function handleMouseDown(event: Event) {
+  if (event.target === searchInputRef.value) {
+    return
+  }
+
+  if (api.multiple && !api.noAutoClose) {
+    event.preventDefault()
   }
 }
 
@@ -79,6 +92,7 @@ const SEARCH_ICON_SIZE = {
   <div
     class="s-select-dropdown"
     :class="`s-select-dropdown_size_${api.size}`"
+    @mousedown="handleMouseDown"
   >
     <div
       v-if="search"
@@ -91,6 +105,7 @@ const SEARCH_ICON_SIZE = {
       />
 
       <input
+        ref="searchInputRef"
         class="s-select-dropdown__search-input flex-grow bg-transparent"
         :class="MAIN_FONT[api.size]"
         :value="api.searchQuery"

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -148,6 +148,7 @@ const SEARCH_ICON_SIZE = {
             v-if="isActionButtonShown(!!optionGroup.selectAllBtn)"
             class="s-select-dropdown__action cursor-pointer ml-auto"
             :class="MAIN_FONT[api.size]"
+            tabindex="-1"
             @click="api.toggleGroupSelection(optionGroup)"
           >
             {{ api.isGroupSelected(optionGroup) ? 'Deselect all' : 'Select all' }}

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -37,6 +37,7 @@ const shownOptionGroups: ComputedRef<SelectOptionGroup[]> = computed(() => {
 
   return optionGroups.value.map((x) => ({ ...x, items: x.items.filter((x) => escapedQuery.value.test(x.label)) }))
 })
+const isNothingToShow = eagerComputed(() => shownOptionGroups.value.every((x) => !x.items.length))
 
 function isActionButtonShown(selectAllBtn: boolean) {
   return api.multiple && selectAllBtn
@@ -103,6 +104,16 @@ const SEARCH_ICON_SIZE = {
       class="s-select-dropdown__loading flex items-center justify-center"
     >
       <SSpinner />
+    </div>
+
+    <div
+      v-else-if="isNothingToShow"
+      class="flex items-center justify-center m-16px"
+      :class="MAIN_FONT[api.size]"
+    >
+      <slot name="empty">
+        No data
+      </slot>
     </div>
 
     <template v-else>

--- a/packages/ui/src/components/Select/SSelectInput.vue
+++ b/packages/ui/src/components/Select/SSelectInput.vue
@@ -2,11 +2,31 @@
 import { useSelectApi } from './api'
 import { SelectSize } from './types'
 import SSelectChevron from './SSelectChevron'
+import SSelectChip from './SSelectChip.vue'
+import STextField from '@/components/TextField/STextField.vue'
+import { IconBasicSearch24 } from '@/components/icons'
+import { MaybeElementRef } from '@vueuse/core'
+
+const props = withDefaults(
+  defineProps<{
+    search?: boolean
+  }>(),
+  {
+    search: false,
+  },
+)
 
 const slots = useSlots()
 const api = useSelectApi()
 
 const selectionsJoined = computed<string>(() => api.selectedOptions.map((x) => x.label).join(', '))
+
+const SEARCH_ICON_SIZE = {
+  [SelectSize.Xl]: 24,
+  [SelectSize.Lg]: 20,
+  [SelectSize.Md]: 18,
+  [SelectSize.Sm]: 15,
+} as const
 
 /**
  * Column layout - when label is on top of the selection.
@@ -16,12 +36,65 @@ const isColumnLayout = computed<boolean>(() => {
   return api.size === SelectSize.Xl
 })
 
+const shouldUseChips = computed(() => api.multiple && props.search)
+
 function typographyLabel(): string {
   return !api.isSomethingSelected && api.size === SelectSize.Xl ? 'sora-tpg-p3' : 'sora-tpg-p4'
 }
 
 function typographySelection(): string {
   return api.size === SelectSize.Xl ? 'sora-tpg-p3' : 'sora-tpg-p4'
+}
+
+const inputRef = ref<MaybeElementRef>(null)
+const isFocused = ref(false)
+const shouldShowLabel = computed(
+  () => !(props.search && (api.searchQuery || api.isSomethingSelected || isFocused.value)),
+)
+
+function focusInput() {
+  if (!(inputRef.value instanceof HTMLInputElement)) {
+    return
+  }
+
+  inputRef.value.focus()
+  isFocused.value = true
+}
+
+function handleInputBlur() {
+  api.menuToggle(false)
+  isFocused.value = false
+}
+
+function handleInputClick(event: MouseEvent) {
+  if (!props.search) {
+    api.menuToggle()
+
+    return
+  }
+
+  if (event.target !== document.activeElement) {
+    event.preventDefault()
+  }
+
+  focusInput()
+  api.menuToggle(true)
+}
+
+function handleMouseDown(event: MouseEvent) {
+  if (event.target === inputRef.value) {
+    return
+  }
+
+  event.preventDefault()
+}
+
+function handleInput(event: Event) {
+  if (!(event.target instanceof HTMLInputElement)) {
+    return
+  }
+
+  api.updateSearchQuery(event.target.value)
 }
 
 const FLabel = () => {
@@ -48,16 +121,63 @@ const FSelection = () =>
 </script>
 
 <template>
+  <STextField
+    v-if="search && isColumnLayout"
+    :model-value="api.searchQuery"
+    :label="api.label || ''"
+    :filled-state="api.isSomethingSelected"
+    :disabled="api.disabled"
+    @update:model-value="api.updateSearchQuery"
+    @click:input-wrapper="api.menuToggle(true)"
+    @blur="api.menuToggle(false)"
+  >
+    <template #label>
+      <slot
+        name="label"
+        v-bind="api"
+      />
+    </template>
+
+    <template #prefix>
+      <template v-if="shouldUseChips">
+        <SSelectChip
+          v-for="option in api.selectedOptions"
+          :key="option.label"
+          :label="option.label"
+          class="min-w-0 mr-8px mt-4px"
+          :class="typographySelection()"
+          @click:delete="api.unselect(option.value)"
+          @mousedown.prevent.stop
+        />
+      </template>
+      <FSelection
+        v-else
+        class="mr-8px"
+      />
+    </template>
+
+    <template #append>
+      <SSelectChevron
+        :rotate="api.isMenuOpened"
+        :variant="24"
+        width="24"
+        height="24"
+      />
+    </template>
+  </STextField>
+
   <div
+    v-else
     :class="[
       's-select-input',
       `s-select-input_size_${api.size}`,
       {
         's-select-input_empty': !api.isSomethingSelected,
-        's-select-input_disabled': api.disabled || api.loading,
+        's-select-input_disabled': api.disabled,
       },
     ]"
-    @click="api.menuToggle()"
+    @click="handleInputClick"
+    @mousedown="handleMouseDown"
   >
     <template v-if="isColumnLayout">
       <div class="flex flex-col flex-1 truncate">
@@ -67,13 +187,57 @@ const FSelection = () =>
     </template>
 
     <template v-else>
-      <div class="flex items-center flex-1 truncate">
-        <FLabel /> <FSelection />
+      <div
+        class="flex items-center flex-1 truncate"
+        :class="{
+          'flex-wrap': shouldUseChips,
+          '-mt-4px': shouldUseChips,
+        }"
+      >
+        <IconBasicSearch24
+          v-if="search && !shouldUseChips"
+          class="s-select-input__search-icon flex-shrink-0 mr-8px"
+          :width="SEARCH_ICON_SIZE[api.size]"
+          :height="SEARCH_ICON_SIZE[api.size]"
+        />
+        <FLabel
+          v-if="shouldShowLabel"
+          :class="{ 'mt-4px': shouldUseChips }"
+        />
+
+        <template v-if="shouldUseChips">
+          <SSelectChip
+            v-for="option in api.selectedOptions"
+            :key="option.label"
+            class="min-w-0 mr-8px mt-4px"
+            :class="typographySelection()"
+            :label="option.label"
+            @click:delete="api.unselect(option.value)"
+            @mousedown.prevent.stop
+          />
+        </template>
+        <FSelection
+          v-else
+          class="min-w-0 flex-grow-1 ml-4px mr-4px"
+        />
+
+        <input
+          v-if="search"
+          ref="inputRef"
+          :value="api.searchQuery"
+          class="min-w-1/4 bg-transparent outline-none flex-grow basis-0"
+          :class="[{ 'mt-4px': shouldUseChips }, typographySelection()]"
+          @input="handleInput"
+          @blur="handleInputBlur"
+        >
       </div>
     </template>
 
     <div>
-      <SSelectChevron :rotate="api.isMenuOpened" />
+      <SSelectChevron
+        :rotate="api.isMenuOpened"
+        :variant="24"
+      />
     </div>
   </div>
 </template>
@@ -90,6 +254,7 @@ const FSelection = () =>
 
   background: theme.token-as-var('sys.color.background');
   color: theme.token-as-var('sys.color.content-primary');
+  border: 1px solid transparent;
 
   &_disabled {
     @apply pointer-events-none opacity-75;
@@ -99,8 +264,15 @@ const FSelection = () =>
     background: theme.token-as-var('sys.color.background-hover');
   }
 
-  &__label {
+  &:focus-within {
+    background: transparent;
+    border: 1px solid theme.token-as-var('sys.color.border-primary');
+  }
+
+  &__label,
+  &__search-icon {
     color: theme.token-as-var('sys.color.content-tertiary');
+    fill: currentColor;
   }
 
   &_size {
@@ -129,6 +301,17 @@ const FSelection = () =>
     @include x-paddings('md', 12px);
     @include x-paddings('lg', 12px);
     @include x-paddings('xl', 16px);
+
+    @mixin y-paddings($size, $pt, $pb) {
+      &_#{$size} {
+        @apply pt-#{$pt} pb-#{$pb};
+      }
+    }
+
+    @include y-paddings('sm', 0, 0);
+    @include y-paddings('md', 4px, 4px);
+    @include y-paddings('lg', 8px, 8px);
+    @include y-paddings('xl', 10px, 6px);
   }
 
   // magic spacing fix

--- a/packages/ui/src/components/Select/SSelectOption.vue
+++ b/packages/ui/src/components/Select/SSelectOption.vue
@@ -38,11 +38,13 @@ const CHECK_ICON_SIZE = {
         's-select-option_selected': selected,
       },
     ]"
+    data-testid="select-option"
     @click="emit('toggle')"
   >
     <template v-if="type === SelectOptionType.Checkbox">
       <SCheckboxAtom
         class="flex-shrink-0"
+        data-testid="select-option-checkbox"
         :checked="selected"
         :size="RADIO_CHECKBOX_SIZE[api.size]"
       />
@@ -50,6 +52,7 @@ const CHECK_ICON_SIZE = {
     <template v-if="type === SelectOptionType.Radio">
       <SRadioAtom
         class="flex-shrink-0"
+        data-testid="select-option-radio"
         :checked="selected"
         :size="RADIO_CHECKBOX_SIZE[api.size]"
       />
@@ -63,6 +66,7 @@ const CHECK_ICON_SIZE = {
       <IconCheckMark
         v-if="selected"
         class="flex-shrink-0"
+        data-testid="select-option-checkmark"
         :width="CHECK_ICON_SIZE[api.size]"
         :height="CHECK_ICON_SIZE[api.size]"
       />

--- a/packages/ui/src/components/Select/SSelectOption.vue
+++ b/packages/ui/src/components/Select/SSelectOption.vue
@@ -42,24 +42,27 @@ const CHECK_ICON_SIZE = {
   >
     <template v-if="type === SelectOptionType.Checkbox">
       <SCheckboxAtom
+        class="flex-shrink-0"
         :checked="selected"
         :size="RADIO_CHECKBOX_SIZE[api.size]"
       />
     </template>
     <template v-if="type === SelectOptionType.Radio">
       <SRadioAtom
+        class="flex-shrink-0"
         :checked="selected"
         :size="RADIO_CHECKBOX_SIZE[api.size]"
       />
     </template>
 
-    <div class="s-select-option__content">
+    <div class="s-select-option__content truncate">
       <slot />
     </div>
 
     <template v-if="type === SelectOptionType.Default">
       <IconCheckMark
         v-if="selected"
+        class="flex-shrink-0"
         :width="CHECK_ICON_SIZE[api.size]"
         :height="CHECK_ICON_SIZE[api.size]"
       />

--- a/packages/ui/src/components/Select/api.ts
+++ b/packages/ui/src/components/Select/api.ts
@@ -12,6 +12,7 @@ export interface SelectApi<T> extends UnwrapRef<UseSelectModelReturn<T>> {
   readonly size: SelectSize
   readonly noAutoClose: boolean
   readonly searchQuery: string
+  readonly remoteSearch: boolean
 
   readonly isMenuOpened: boolean
   /**

--- a/packages/ui/src/components/Select/sizes-mixin.scss
+++ b/packages/ui/src/components/Select/sizes-mixin.scss
@@ -1,17 +1,17 @@
 @mixin s-select-sizes {
   &_sm {
-    height: 24px;
+    min-height: 24px;
   }
 
   &_md {
-    height: 32px;
+    min-height: 32px;
   }
 
   &_lg {
-    height: 40px;
+    min-height: 40px;
   }
 
   &_xl {
-    height: 56px;
+    min-height: 56px;
   }
 }

--- a/packages/ui/src/components/Select/use-model.spec.ts
+++ b/packages/ui/src/components/Select/use-model.spec.ts
@@ -91,7 +91,7 @@ describe('Auto-closing', () => {
 })
 
 describe('Storing options', () => {
-  test('when select option and then it removed from options list it is selected anyway', () => {
+  test('when selected option is removed from options list, it is selected anyway', () => {
     const changingOptions = ref(OPTIONS)
     const modeling = useSelectModel({
       model: ref(null),

--- a/packages/ui/src/components/Select/use-model.spec.ts
+++ b/packages/ui/src/components/Select/use-model.spec.ts
@@ -9,10 +9,14 @@ const OPTIONS = [
 ]
 
 describe('Auto-closing', () => {
-  function useFactory(props: Except<UseSelectModelParams<any>, 'options' | 'multiple'>, mode: 'single' | 'multi') {
+  function useFactory(
+    props: Except<UseSelectModelParams<any>, 'options' | 'multiple' | 'storeSelectedOptions'>,
+    mode: 'single' | 'multi',
+  ) {
     return useSelectModel({
       options: ref(OPTIONS),
       multiple: ref(mode === 'multi' ? true : false),
+      storeSelectedOptions: ref(false),
       ...props,
     })
   }
@@ -83,5 +87,27 @@ describe('Auto-closing', () => {
     modeling.unselect('thin')
 
     expect(onAutoClose).not.toBeCalled()
+  })
+})
+
+describe('Storing options', () => {
+  test('when select option and then it removed from options list it is selected anyway', () => {
+    const changingOptions = ref(OPTIONS)
+    const modeling = useSelectModel({
+      model: ref(null),
+      options: changingOptions,
+      multiple: ref(true),
+      storeSelectedOptions: ref(true),
+      singleModeAutoClose: ref(true),
+      onAutoClose: () => {},
+    })
+
+    modeling.select('thin')
+    modeling.select('regular')
+    modeling.select('deep')
+
+    changingOptions.value = [OPTIONS[1], OPTIONS[2]]
+
+    expect(modeling.selectedOptions.value).toHaveLength(3)
   })
 })

--- a/packages/ui/src/components/Select/use-model.ts
+++ b/packages/ui/src/components/Select/use-model.ts
@@ -139,7 +139,7 @@ export function useSelectModel<T = any>({
       modelChangedManually = true
 
       if (storeSelectedOptions.value) {
-        let oldValue = Array.isArray(model.value) ? model.value[0] : model.value;
+        let oldValue = Array.isArray(model.value) ? model.value[0] : model.value
 
         if (oldValue) {
           forgetOption(oldValue)

--- a/packages/ui/src/components/Select/use-model.ts
+++ b/packages/ui/src/components/Select/use-model.ts
@@ -32,9 +32,9 @@ export interface UseSelectModelParams<T> {
   model: Ref<null | T | T[]>
   options: Ref<SelectOption<T>[] | SelectOptionGroup<T>[]>
   /**
-   * Enables remembering options for async search in multiple select when option list
-   * changes on search query changes. If no option creates option without label (e.g. for cases when model changes
-   * from outside and has values that have no options for them)
+   * Enables options remembering for async search in multiple select when, for example,
+   * the options are changed on search query changes. If there are no options for selected values,
+   * then options without labels are created (e.g. for cases when model is changed externally)
    */
   storeSelectedOptions: Ref<boolean>
   singleModeAutoClose: Ref<boolean>

--- a/packages/ui/src/components/TextField/STextField.vue
+++ b/packages/ui/src/components/TextField/STextField.vue
@@ -402,18 +402,18 @@ $theme-content-tertiary: theme.token-as-var('sys.color.content-tertiary');
       // primary state by default
       transform: translateY(#{$label-top-primary});
     }
+  }
 
-    #{$root}__input-line {
-      @apply flex flex-wrap cursor-text;
-      padding: $input-padding;
+  &__input-line {
+    @apply flex flex-wrap cursor-text min-w-0;
+    padding: $input-padding;
 
-      input {
-        @apply flex-1 w-full min-w-1/4;
+    input {
+      @apply flex-1 w-full min-w-1/4;
 
-        background: transparent;
-        &:focus {
-          outline: none;
-        }
+      background: transparent;
+      &:focus {
+        outline: none;
       }
     }
   }

--- a/packages/ui/src/components/TextField/STextField.vue
+++ b/packages/ui/src/components/TextField/STextField.vue
@@ -283,6 +283,7 @@ const inputType = computed(() =>
         <input
           :id="id"
           ref="inputRef"
+          class="sora-tpg-p3"
           :value="model"
           :type="inputType"
           :disabled="disabled"

--- a/packages/ui/src/components/TextField/STextField.vue
+++ b/packages/ui/src/components/TextField/STextField.vue
@@ -391,7 +391,7 @@ $theme-content-tertiary: theme.token-as-var('sys.color.content-tertiary');
   }
 
   &__input-line {
-    @apply flex flex-wrap min-w-0;
+    @apply flex flex-wrap flex-grow min-w-0;
     padding: $input-padding;
 
     input {

--- a/packages/ui/stories/SSelect.stories.ts
+++ b/packages/ui/stories/SSelect.stories.ts
@@ -52,6 +52,10 @@ const OPTIONS: SelectOption[] = [
     value: 'en',
   },
   {
+    label: 'United Arab Emirates',
+    value: 'ae',
+  },
+  {
     label: 'Iceland',
     value: 'is',
   },
@@ -72,6 +76,10 @@ const OPTION_GROUPS: SelectOptionGroup[] = [
       {
         label: 'England',
         value: 'en',
+      },
+      {
+        label: 'United Arab Emirates',
+        value: 'ae',
       },
     ],
   },
@@ -202,6 +210,13 @@ export const Dropdown = defineStory((args) => ({
 Dropdown.argTypes = commonArgTypes
 Dropdown.args = commonArgs
 
+const modelSingle = ref()
+const modelSingleRemote = ref()
+const modelMultiple = ref()
+const modelMultipleRemote = ref()
+const modelDropdown = ref()
+const modelDropdownDropdown = ref()
+
 export const WithSearch = defineStory((args) => ({
   components: { SSelect, SDropdown },
   setup() {
@@ -220,35 +235,84 @@ export const WithSearch = defineStory((args) => ({
       OPTION_GROUPS,
       asyncOptions,
       isLoadingAsyncOptions,
-      model: ref(['en', 'jp']),
+      modelSingle,
+      modelSingleRemote,
+      modelMultiple,
+      modelMultipleRemote,
+      modelDropdown,
+      modelDropdownDropdown,
       handleSearch,
       args,
     }
   },
   template: `
-    <SDropdown
-      v-model="model"
+    <SSelect
+      v-model="modelSingle"
       label="Search"
       :options="OPTION_GROUPS"
-      multiple
       :size="args.size"
       :disabled="args.disabled"
       :loading="args.loading"
       :option-type="args.optionType"
-      dropdown-search
+      trigger-search
     />
     <SSelect
-      v-model="model"
+      v-model="modelSingleRemote"
       label="Remote search"
       :options="asyncOptions"
-      multiple
       :size="args.size"
       :disabled="args.disabled"
       :loading="isLoadingAsyncOptions"
       :option-type="args.optionType"
-      dropdown-search
+      trigger-search
       remote-search
       @search="handleSearch"
+    />
+    <SSelect
+      v-model="modelMultiple"
+      label="Search - multiple"
+      :options="OPTION_GROUPS"
+      :size="args.size"
+      :disabled="args.disabled"
+      :loading="args.loading"
+      :option-type="args.optionType"
+      multiple
+      trigger-search
+    />
+    <SSelect
+      v-model="modelMultipleRemote"
+      label="Remote search - multiple"
+      :options="asyncOptions"
+      :size="args.size"
+      :disabled="args.disabled"
+      :loading="isLoadingAsyncOptions"
+      :option-type="args.optionType"
+      multiple
+      trigger-search
+      remote-search
+      @search="handleSearch"
+    />
+    <SSelect
+      v-model="modelDropdown"
+      label="Menu search"
+      :options="OPTION_GROUPS"
+      :size="args.size"
+      :disabled="args.disabled"
+      :loading="args.loading"
+      :option-type="args.optionType"
+      multiple
+      dropdown-search
+    />
+    <SDropdown
+      v-model="modelDropdownDropdown"
+      label="Menu search"
+      :options="OPTION_GROUPS"
+      :size="args.size"
+      :disabled="args.disabled"
+      :loading="args.loading"
+      :option-type="args.optionType"
+      multiple
+      dropdown-search
     />
   `,
 }))

--- a/packages/ui/stories/SSelect.stories.ts
+++ b/packages/ui/stories/SSelect.stories.ts
@@ -205,16 +205,30 @@ Dropdown.args = commonArgs
 export const WithSearch = defineStory((args) => ({
   components: { SSelect, SDropdown },
   setup() {
+    const asyncOptions = shallowRef([...OPTIONS])
+    const isLoadingAsyncOptions = ref(false)
+
+    async function handleSearch(value: string) {
+      isLoadingAsyncOptions.value = true
+      asyncOptions.value = await new Promise((resolve) => {
+        setTimeout(() => resolve(OPTIONS.filter((x) => new RegExp(value, 'i').test(x.label))), 1000)
+      })
+      isLoadingAsyncOptions.value = false
+    }
+
     return {
       OPTION_GROUPS,
+      asyncOptions,
+      isLoadingAsyncOptions,
       model: ref(['en', 'jp']),
+      handleSearch,
       args,
     }
   },
   template: `
-    <SSelect
+    <SDropdown
       v-model="model"
-      label="Multi select"
+      label="Search"
       :options="OPTION_GROUPS"
       multiple
       :size="args.size"
@@ -222,6 +236,19 @@ export const WithSearch = defineStory((args) => ({
       :loading="args.loading"
       :option-type="args.optionType"
       dropdown-search
+    />
+    <SSelect
+      v-model="model"
+      label="Remote search"
+      :options="asyncOptions"
+      multiple
+      :size="args.size"
+      :disabled="args.disabled"
+      :loading="isLoadingAsyncOptions"
+      :option-type="args.optionType"
+      dropdown-search
+      remote-search
+      @search="handleSearch"
     />
   `,
 }))


### PR DESCRIPTION
(after https://github.com/soramitsu/soramitsu-js-ui-library/pull/497)
Text field:
- add `prefix` slot - inline elements before input and `filledState` prop to use filled state when prefix presents
- fix input font

Select:
- add empty slot for menu
- add `triggerSearch` prop to enable search input in select input
- add `remoteSearch` prop that disables default search behaviour