### PR TITLE
WDS-119 fix styles for radio and checkbox components

### DIFF
--- a/.changeset/famous-sheep-flow.md
+++ b/.changeset/famous-sheep-flow.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`SCheckbox`, `SRadio`): removed redundant hover background and change paddings

--- a/packages/ui/src/components/Checkbox/SCheckboxSolo.vue
+++ b/packages/ui/src/components/Checkbox/SCheckboxSolo.vue
@@ -72,25 +72,3 @@ const hover = ref(false)
     </template>
   </SRadioBody>
 </template>
-
-<style lang="scss">
-@use '@/theme';
-
-.s-checkbox-solo.s-radio-body {
-  &[aria-disabled='true'] {
-    pointer-events: none;
-
-    label,
-    .s-radio-body__description {
-      color: theme.token-as-var('sys.color.on-disabled');
-    }
-  }
-
-  &[data-type^='bordered'] {
-    &:hover,
-    &[aria-checked='true']:not([aria-disabled]) {
-      border-color: theme.token-as-var('sys.color.primary');
-    }
-  }
-}
-</style>

--- a/packages/ui/src/components/Radio/SRadio.vue
+++ b/packages/ui/src/components/Radio/SRadio.vue
@@ -92,27 +92,3 @@ const describedBy = computed(() => (definitelyType.value === 'bordered-with-desc
     </svg>
   </SRadioBody>
 </template>
-
-<style lang="scss">
-@use '@/theme';
-
-.s-radio.s-radio-body {
-  $root: &;
-
-  &[aria-disabled='true'] {
-    pointer-events: none;
-
-    label,
-    .s-radio-body__description {
-      color: theme.token-as-var('sys.color.on-disabled');
-    }
-  }
-
-  &[data-type^='bordered'] {
-    &:hover,
-    &[aria-checked='true']:not([aria-disabled='true']) {
-      border-color: theme.token-as-var('sys.color.primary');
-    }
-  }
-}
-</style>

--- a/packages/ui/src/components/Radio/SRadioBody.scss
+++ b/packages/ui/src/components/Radio/SRadioBody.scss
@@ -8,7 +8,6 @@ $dur-easing: 0.2s ease;
 
 .s-radio-body {
   @apply select-none cursor-pointer rounded;
-  padding: 8px 10px;
   transition: all $dur-easing;
 
   $root: &;
@@ -43,27 +42,37 @@ $dur-easing: 0.2s ease;
     transition: color $dur-easing;
   }
 
+  &[aria-disabled='true'] {
+    pointer-events: none;
+
+    label,
+    .s-radio-body__description {
+      color: theme.token-as-var('sys.color.on-disabled');
+    }
+  }
+
   &[data-type^='bordered'] {
     border: 1px solid $border-primary;
 
-    // should be controlled externally
-
-    // &:hover,
-    // &[aria-checked='true']:not([aria-disabled='true']) {
-    //   border-color: $primary;
-    // }
+    &:hover,
+    &[aria-checked='true']:not([aria-disabled='true']) {
+      border-color: $primary;
+    }
   }
 
-  // Styles below doesn't come from design
-  // FIXME
-
-  &:hover {
-    @apply bg-gray-50;
+  @mixin padding($type, $size, $px, $py) {
+    &[data-size='#{$size}'][data-type='#{$type}'] {
+      padding: $py $px;
+    }
   }
 
-  &:active {
-    @apply bg-gray-100;
-  }
+  @include padding('bordered', 'md', 8px, 6px);
+  @include padding('bordered', 'lg', 10px, 8px);
+  @include padding('bordered', 'xl', 10px, 10px);
+
+  @include padding('bordered-with-description', 'md', 10px, 8px);
+  @include padding('bordered-with-description', 'lg', 12px, 10px);
+  @include padding('bordered-with-description', 'xl', 16px, 16px);
 
   &:focus {
     @apply ring ring-opacity-25 ring-blue-500 ring-offset-2;

--- a/packages/ui/src/components/Radio/SRadioBody.ts
+++ b/packages/ui/src/components/Radio/SRadioBody.ts
@@ -20,6 +20,7 @@ const SRadioBody: FunctionalComponent<Props> = (props, { attrs, slots }) => {
       {
         class: 's-radio-body',
         'data-type': props.type,
+        'data-size': props.size,
         'aria-labelledby': props.labelId,
         'aria-describedby': props.descriptionId,
       },


### PR DESCRIPTION
Checkbox and radio:
- refactor: moved common styles to common component
- added different paddings for different sizes and types
- removed hover background that was not in design