### PR TITLE
Fix center state for arrow in collapse fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu/soramitsu-js-ui",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "private": false,
   "publishConfig": {
     "registry": "https://nexus.iroha.tech/repository/npm-soramitsu/"

--- a/src/styles/collapse.scss
+++ b/src/styles/collapse.scss
@@ -29,6 +29,9 @@
       border-bottom-color: transparent;
     }
     .el-icon-arrow-right {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       &,
       &::before {
         font-family: var(--s-font-family-icons);
@@ -36,9 +39,6 @@
       &::before {
         position: absolute;
         transition: transform 0.25s ease-in-out;
-        display: flex;
-        justify-content: center;
-        align-items: center;
       }
       @extend .s-icon-chevron-down-rounded-16;
       font-size: var(--s-icon-font-size-mini);


### PR DESCRIPTION
Hello!
Looks like CSS attributes were mistakenly applied to another element.
The arrow was especially noticeable off-center at 125% and 175% zoom.

Showcase:
https://user-images.githubusercontent.com/2076748/227840869-03d82806-7957-41f6-934e-9e77be905529.mp4

