### PR TITLE
update node v16

### DIFF
--- a/next.Jenkinsfile
+++ b/next.Jenkinsfile
@@ -2,7 +2,7 @@
 def pipeline = new org.js.LibPipeline(
     steps:                this,
     packageManager:       'yarn',
-    buildDockerImage:     'build-tools/node:14-ubuntu-cypress',
+    buildDockerImage:     'build-tools/node:16-ubuntu-cypress',
     npmLoginEmail:        'admin@soramitsu.co.jp',
     dockerFileName:       'next.Dockerfile',
     dockerImageName:      'soramitsu/soramitsu-js-ui-library',


### PR DESCRIPTION
# Task

Change Node's version that is used in branch "next" from 14 to 16

## Changes

1. node:16-ubuntu-cypress image added


## Author

Signed-off-by: Naghme Mohammadifar <mohammadi.far@soramitsu.co.jp>

