### PR TITLE
WDS-128 time disable, fix vmodel watch, no shortcuts

### DIFF
--- a/.changeset/nervous-monkeys-bow.md
+++ b/.changeset/nervous-monkeys-bow.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+**feat**(`SDatePicker`): make date filters work for time panel

--- a/.changeset/serious-dragons-clap.md
+++ b/.changeset/serious-dragons-clap.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`SDatePicker`): add value prop watching

--- a/.changeset/tough-hounds-help.md
+++ b/.changeset/tough-hounds-help.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': minor
+---
+
+**feat**(`SDatePicker`): make possible to show date picker without shortcuts menu

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -101,15 +101,15 @@ export interface DatePickerOptions {
     // Warning: (ae-forgotten-export) The symbol "PresetOptionCustom" needs to be exported by the entry point lib.d.ts
     //
     // (undocumented)
-    day: [...PresetOption<DayModelValue>[], PresetOptionCustom];
+    day: [...PresetOption<DayModelValue>[], PresetOptionCustom] | [];
     // Warning: (ae-forgotten-export) The symbol "PickModelValue" needs to be exported by the entry point lib.d.ts
     //
     // (undocumented)
-    pick: [...PresetOption<PickModelValue>[], PresetOptionCustom];
+    pick: [...PresetOption<PickModelValue>[], PresetOptionCustom] | [];
     // Warning: (ae-forgotten-export) The symbol "RangeModelValue" needs to be exported by the entry point lib.d.ts
     //
     // (undocumented)
-    range: [...PresetOption<RangeModelValue>[], PresetOptionCustom];
+    range: [...PresetOption<RangeModelValue>[], PresetOptionCustom] | [];
 }
 
 // @public (undocumented)
@@ -277,11 +277,6 @@ export { RadioType as CheckboxType }
 export { RadioType }
 
 // @public (undocumented)
-export type RangePickEventValue = RangeState & {
-    selectedField: string;
-};
-
-// @public (undocumented)
 export type RangeState = RangeStateEmpty | RangeStateSelecting | RangeStateSelected;
 
 // Warning: (ae-forgotten-export) The symbol "RangeStateBase" needs to be exported by the entry point lib.d.ts
@@ -290,6 +285,8 @@ export type RangeState = RangeStateEmpty | RangeStateSelecting | RangeStateSelec
 export interface RangeStateEmpty extends RangeStateBase {
     // (undocumented)
     endDate: null;
+    // (undocumented)
+    selectedField: null;
     // (undocumented)
     selecting: false;
     // (undocumented)
@@ -301,6 +298,8 @@ export interface RangeStateSelected extends RangeStateBase {
     // (undocumented)
     endDate: Date;
     // (undocumented)
+    selectedField: 'startDate' | 'endDate';
+    // (undocumented)
     selecting: false;
     // (undocumented)
     startDate: Date;
@@ -310,6 +309,8 @@ export interface RangeStateSelected extends RangeStateBase {
 export interface RangeStateSelecting extends RangeStateBase {
     // (undocumented)
     endDate: null;
+    // (undocumented)
+    selectedField: 'startDate' | 'endDate';
     // (undocumented)
     selecting: true;
     // (undocumented)
@@ -580,7 +581,7 @@ max: null;
 type: DatePickerType;
 disabled: boolean;
 time: boolean;
-shortcuts: DatePickerOptionsProp;
+shortcuts: false | DatePickerOptionsProp;
 dateFilter: (d: Date) => boolean;
 min: Date | null;
 max: Date | null;

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -336,7 +336,7 @@ const timeOptions = computed(() => {
 })
 
 const updateTime = (time: string) => {
-  if (!lastPickedDate.value) return
+  if (!props.time || !lastPickedDate.value) return
 
   switch (props.type) {
     case 'pick':

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -47,6 +47,13 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const innerModelValue = shallowRef<ModelValueType>(props.modelValue)
+watch(
+  () => props.modelValue,
+  (value) => {
+    innerModelValue.value = value
+  },
+  { flush: 'sync' },
+)
 
 const emit = defineEmits(['update:modelValue'])
 
@@ -298,14 +305,14 @@ const headTitle = computed(() => {
   try {
     switch (props.type) {
       case 'day':
-        return formatDate(props.modelValue)
+        return formatDate(innerModelValue.value)
       case 'range': {
-        const modelValue = props.modelValue as Date[]
+        const modelValue = innerModelValue.value as Date[]
         return modelValue.map((item) => formatDate(item)).join(' - ')
       }
 
       case 'pick': {
-        const modelValue = props.modelValue as Date[]
+        const modelValue = innerModelValue.value as Date[]
         return modelValue.map((item) => formatDate(item)).join(', ')
       }
       default:

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -431,19 +431,23 @@ const showCustomInputs = computed(() => {
   return selectedMenuOption.value.value === CUSTOM_OPTION_VALUE && !showStateView.value
 })
 
-watch(innerModelValue, () => {
-  if (props.type === 'day') {
-    dayState.value = innerModelValue.value as DateState
-  } else if (props.type === 'pick') {
-    pickState.value = (innerModelValue.value as PickState | null) ?? []
-  } else {
-    if (Array.isArray(innerModelValue.value) && innerModelValue.value.length === 2) {
-      ;[rangeState.value.startDate, rangeState.value.endDate] = innerModelValue.value
+watch(
+  innerModelValue,
+  () => {
+    if (props.type === 'day') {
+      dayState.value = innerModelValue.value as DateState
+    } else if (props.type === 'pick') {
+      pickState.value = (innerModelValue.value as PickState | null) ?? []
+    } else {
+      if (Array.isArray(innerModelValue.value) && innerModelValue.value.length === 2) {
+        ;[rangeState.value.startDate, rangeState.value.endDate] = innerModelValue.value
+      }
     }
-  }
 
-  updateShowedMonths()
-}, { immediate: true })
+    updateShowedMonths()
+  },
+  { immediate: true },
+)
 </script>
 
 <template>

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -444,7 +444,7 @@ watch(innerModelValue, () => {
   }
 
   updateShowedMonths()
-})
+}, { immediate: true })
 </script>
 
 <template>

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -288,14 +288,13 @@ const headTitle = computed(() => {
         const modelValue = innerModelValue.value as Date[]
         return modelValue.map((item) => formatDate(item)).join(' - ')
       }
-
       case 'pick': {
         const modelValue = innerModelValue.value as Date[]
         return modelValue.map((item) => formatDate(item)).join(', ')
       }
-      default:
-        break
     }
+
+    return ''
   } catch {
     return ''
   }

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -31,7 +31,7 @@ interface Props {
   type?: DatePickerType
   time?: boolean
   disabled?: boolean
-  shortcuts?: DatePickerOptionsProp
+  shortcuts?: DatePickerOptionsProp | false
   dateFilter?: (d: Date) => boolean
   min?: Date | null
   max?: Date | null
@@ -232,6 +232,8 @@ const onMenuClick = (data: PossiblePresetOption) => {
 }
 
 const finalShortcuts = computed((): Required<DatePickerOptions> => {
+  if (!props.shortcuts) return { day: [], range: [], pick: [] }
+
   return {
     day: [...(props.shortcuts.day ?? []), CUSTOM_OPTION],
     range: [...(props.shortcuts.range ?? []), CUSTOM_OPTION],
@@ -512,7 +514,7 @@ init(innerModelValue.value)
             :class="[`${gridType}`, { 'narrow': showStateView }]"
           >
             <OptionsPanel
-              v-if="type !== 'pick'"
+              v-if="shortcuts && type !== 'pick'"
               :type="type"
               :menu-state="selectedMenuOption.label"
               :options="finalShortcuts"

--- a/packages/ui/src/components/DatePicker/SDatePicker.vue
+++ b/packages/ui/src/components/DatePicker/SDatePicker.vue
@@ -97,20 +97,6 @@ const stateStore = computed<StateStore>(() => {
   }
 })
 
-function init(initialValue: ModelValueType) {
-  if (props.type === 'day') {
-    dayState.value = initialValue as DateState
-  } else if (props.type === 'pick') {
-    pickState.value = (initialValue as PickState | null) ?? []
-  } else {
-    if (Array.isArray(initialValue) && initialValue.length === 2) {
-      ;[rangeState.value.startDate, rangeState.value.endDate] = initialValue
-    }
-  }
-
-  updateShowedMonths()
-}
-
 const updateModelValue = () => {
   if (props.type === 'day') {
     innerModelValue.value = dayState.value
@@ -464,7 +450,19 @@ const showCustomInputs = computed(() => {
   return selectedMenuOption.value.value === CUSTOM_OPTION_VALUE && !showStateView.value
 })
 
-init(innerModelValue.value)
+watch(innerModelValue, () => {
+  if (props.type === 'day') {
+    dayState.value = innerModelValue.value as DateState
+  } else if (props.type === 'pick') {
+    pickState.value = (innerModelValue.value as PickState | null) ?? []
+  } else {
+    if (Array.isArray(innerModelValue.value) && innerModelValue.value.length === 2) {
+      ;[rangeState.value.startDate, rangeState.value.endDate] = innerModelValue.value
+    }
+  }
+
+  updateShowedMonths()
+})
 </script>
 
 <template>

--- a/packages/ui/src/components/DatePicker/SDatePickerPanelTime.vue
+++ b/packages/ui/src/components/DatePicker/SDatePickerPanelTime.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { TIME_POINTS } from './consts'
+import { DatePickerApi, useDatePickerApi } from '@/components/DatePicker/api'
 
 interface Props {
   value: string
+  options: string[]
 }
+
+const state: DatePickerApi = useDatePickerApi()
 
 const props = withDefaults(defineProps<Props>(), {
   value: '00:00',
@@ -19,7 +22,7 @@ const updateTime = (e: any) => {
 <template>
   <div class="s-date-picker-time-panel sora-tpg-p4">
     <p
-      v-for="(time, idx) in TIME_POINTS"
+      v-for="(time, idx) in options"
       :key="idx"
       class="cursor-pointer"
       :class="time === value ? 'active' : ''"

--- a/packages/ui/src/components/DatePicker/SDatePickerTableDate.vue
+++ b/packages/ui/src/components/DatePicker/SDatePickerTableDate.vue
@@ -245,8 +245,9 @@ const handleClick = (ev: any) => {
         startDate: newDate,
         endDate: null,
         selecting: true,
+        selectedField: 'startDate',
       }
-      emit('pick', { ...rangeStateSelecting, selectedField: 'startDate' })
+      emit('pick', rangeStateSelecting)
     } else {
       const dat = props.stateStore.rangeState.startDate
       if (dat && newDate >= dat) {
@@ -254,15 +255,17 @@ const handleClick = (ev: any) => {
           startDate: dat,
           endDate: newDate,
           selecting: false,
+          selectedField: 'endDate',
         }
-        emit('pick', { ...rangeStateSelected, selectedField: 'endDate' })
+        emit('pick', rangeStateSelected)
       } else {
         const rangeStateSelected: RangeStateSelected = {
           startDate: newDate,
           endDate: dat,
           selecting: false,
+          selectedField: 'startDate',
         }
-        emit('pick', { ...rangeStateSelected, selectedField: 'startDate' })
+        emit('pick', rangeStateSelected)
       }
     }
   } else if (state.type === 'day') {

--- a/packages/ui/src/components/DatePicker/api.ts
+++ b/packages/ui/src/components/DatePicker/api.ts
@@ -6,7 +6,7 @@ export interface DatePickerApi {
   type: DatePickerType
   time: boolean
   disabled: boolean
-  dateFilter: (d: Date) => boolean
+  dateFilter: (d: Date, precision: 'date' | 'datetime') => boolean
 }
 
 export const DATE_PICKER_API_KEY: InjectionKey<DatePickerApi> = Symbol('datePicker')

--- a/packages/ui/src/components/DatePicker/api.ts
+++ b/packages/ui/src/components/DatePicker/api.ts
@@ -6,7 +6,7 @@ export interface DatePickerApi {
   type: DatePickerType
   time: boolean
   disabled: boolean
-  dateFilter: (d: Date, precision: 'date' | 'datetime') => boolean
+  dateFilter: (d: Date, precision?: 'date' | 'datetime') => boolean
 }
 
 export const DATE_PICKER_API_KEY: InjectionKey<DatePickerApi> = Symbol('datePicker')

--- a/packages/ui/src/components/DatePicker/date-util.ts
+++ b/packages/ui/src/components/DatePicker/date-util.ts
@@ -16,3 +16,9 @@ export const prevDate = (date: Date, amount = 1) => {
 export const nextDate = (date: Date, amount = 1) => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + amount)
 }
+
+export function setTimeByString(date: Date, time: string) {
+  const [hours, minutes] = time.split(':').map((item) => Number(item))
+
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), hours, minutes, 0)
+}

--- a/packages/ui/src/components/DatePicker/types.ts
+++ b/packages/ui/src/components/DatePicker/types.ts
@@ -62,9 +62,9 @@ export interface DatePickerOptionsProp {
 }
 
 export interface DatePickerOptions {
-  day: [...PresetOption<DayModelValue>[], PresetOptionCustom]
-  range: [...PresetOption<RangeModelValue>[], PresetOptionCustom]
-  pick: [...PresetOption<PickModelValue>[], PresetOptionCustom]
+  day: [...PresetOption<DayModelValue>[], PresetOptionCustom] | []
+  range: [...PresetOption<RangeModelValue>[], PresetOptionCustom] | []
+  pick: [...PresetOption<PickModelValue>[], PresetOptionCustom] | []
 }
 
 export interface ShowState {

--- a/packages/ui/src/components/DatePicker/types.ts
+++ b/packages/ui/src/components/DatePicker/types.ts
@@ -11,29 +11,31 @@ interface RangeStateBase {
   selecting: boolean
   startDate: Date | null
   endDate: Date | null
+  selectedField: 'startDate' | 'endDate' | null
 }
 
 export interface RangeStateSelecting extends RangeStateBase {
   selecting: true
   startDate: Date
   endDate: null
+  selectedField: 'startDate' | 'endDate'
 }
 
 export interface RangeStateSelected extends RangeStateBase {
   selecting: false
   startDate: Date
   endDate: Date
+  selectedField: 'startDate' | 'endDate'
 }
 
 export interface RangeStateEmpty extends RangeStateBase {
   selecting: false
   startDate: null
   endDate: null
+  selectedField: null
 }
 
 export type RangeState = RangeStateEmpty | RangeStateSelecting | RangeStateSelected
-
-export type RangePickEventValue = RangeState & { selectedField: string }
 
 export type DateState = DayModelValue
 export type PickState = PickModelValue


### PR DESCRIPTION
Fixed no watch value prop
Added the ability to show picker without shortcuts
Make time panel also filtered by `dateFilter`, `min`, `max` prop