### PR TITLE
Fix - Remove column width rounding

### DIFF
--- a/.changeset/brave-plums-count.md
+++ b/.changeset/brave-plums-count.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': patch
 ---
 
-**fix**: Remove column width rounding
+**fix**(`STable`): remove column width rounding

--- a/.changeset/brave-plums-count.md
+++ b/.changeset/brave-plums-count.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': patch
 ---
 
-**fix**(`STable`): remove column width rounding and apply overflow-y:auto to the whole table
+**fix**(`STable`): remove column width rounding

--- a/.changeset/brave-plums-count.md
+++ b/.changeset/brave-plums-count.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**: Remove column width rounding

--- a/.changeset/brave-plums-count.md
+++ b/.changeset/brave-plums-count.md
@@ -2,4 +2,4 @@
 '@soramitsu-ui/ui': patch
 ---
 
-**fix**(`STable`): remove column width rounding
+**fix**(`STable`): remove column width rounding and apply overflow-y:auto to the whole table

--- a/.changeset/sweet-knives-obey.md
+++ b/.changeset/sweet-knives-obey.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`STable`): apply overflow-y:auto to the whole table

--- a/packages/ui/src/components/Table/STable.vue
+++ b/packages/ui/src/components/Table/STable.vue
@@ -817,9 +817,7 @@ function handleHeaderMouseEvent(ctx: { column: TableColumnApi | TableActionColum
 $col-number: v-bind(cardsGridColumnNumber);
 
 .s-table {
-  &__body-wrapper {
-    overflow-y: auto;
-  }
+  overflow-y: auto;
 
   &__cards-grid {
     display: grid;

--- a/packages/ui/src/components/Table/use-flex-columns-widths.ts
+++ b/packages/ui/src/components/Table/use-flex-columns-widths.ts
@@ -18,7 +18,7 @@ export function useFlexColumns(
         return columns.map((col) => {
           if (col.width) return col.width
 
-          return col.minWidth + Math.floor((col.minWidth * freeSpace) / columnsMinWidthsSum)
+          return col.minWidth + (col.minWidth * freeSpace) / columnsMinWidthsSum
         })
       }
     }


### PR DESCRIPTION
This pr created in order to remove space between column and border line as in the following picture.

![image](https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/6daeb934-47c8-4bf9-b245-04b0d4bd42e5)

Also I edited STable styles by applying overflow-y:auto to the whole table.