### PR TITLE
Fix - Edit SAlert icon computation

### DIFF
--- a/.changeset/bright-boats-wash.md
+++ b/.changeset/bright-boats-wash.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`SAlert`): edit status icon computation

--- a/packages/ui/src/components/Alert/SAlert.vue
+++ b/packages/ui/src/components/Alert/SAlert.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { IconClose, STATUS_ICONS_MAP } from '@/components/icons'
 import { Status } from '@/types'
+import type { Component } from 'vue'
 
 interface Props {
   inline?: boolean
@@ -17,7 +18,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<(event: 'click:close') => void>()
 
-const StatusIcon = eagerComputed(() => STATUS_ICONS_MAP[props.status])
+const StatusIcon = shallowRef<Component>()
+
+watchSyncEffect(() => {
+  StatusIcon.value = STATUS_ICONS_MAP[props.status]
+})
 
 function onClickClose() {
   emit('click:close')


### PR DESCRIPTION
Motivation:
Current SAlert implementation has warning because of the status icon computation. 
<img width="611" alt="Снимок экрана 2024-05-08 в 00 32 53" src="https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/1c7f4005-aad6-4816-96f2-2ef4ebcd2a71">

Now, we will use it's implementation instead of itself.
Instead of using eagerComputed
```
const StatusIcon = eagerComputed(() => STATUS_ICONS_MAP[props.status])
```
We will use native Vue watshSyncEffect
```
const StatusIcon = shallowRef<Component>()

watchSyncEffect(() => {
  StatusIcon.value = STATUS_ICONS_MAP[props.status]
})
```
Warning resolved✅
By the way, in Vue 3.4+ native computed was greatly improved and later we can replace every eagerComputed usage with it.