### PR TITLE
Fix - Add generics to table data

### DIFF
--- a/.changeset/wise-pens-move.md
+++ b/.changeset/wise-pens-move.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**feat**(`STable`): add generics types of provided data

--- a/.changeset/wise-pens-move.md
+++ b/.changeset/wise-pens-move.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**feat**(`STable`): add generics types of provided data

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @soramitsu-ui/ui
 
+## 0.13.9
+
+### Patch Changes
+
+- 2a85253a: **feat**(`STable`): add generics types of provided data
+
 ## 0.13.8
 
 ### Patch Changes

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -24,6 +24,7 @@ import { PropType as PropType_2 } from 'vue';
 import type { Ref as Ref_2 } from 'vue';
 import { RendererElement } from 'vue';
 import { RendererNode } from 'vue';
+import { ShallowUnwrapRef } from 'vue';
 import type { Slot } from 'vue';
 import { Status as Status_2 } from '@/types';
 import type { StyleValue } from 'vue';
@@ -1026,7 +1027,7 @@ export const SNotificationsProvider: FunctionalComponent<{
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const SPagination: __VLS_WithTemplateSlots_29<DefineComponent<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
+export const SPagination: __VLS_WithTemplateSlots_28<DefineComponent<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
 total?: number | undefined;
 pageSize?: number | null | undefined;
 currentPage?: number | undefined;
@@ -1043,7 +1044,7 @@ sizesLabel: string;
 "click:next": (value: number) => void;
 "update:currentPage": (value: number) => void;
 "update:pageSize": (value: number) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
 total?: number | undefined;
 pageSize?: number | null | undefined;
 currentPage?: number | undefined;
@@ -1574,194 +1575,256 @@ disabled: boolean;
     default?(_: {}): any;
 }>;
 
-// Warning: (ae-forgotten-export) The symbol "__VLS_WithTemplateSlots" needs to be exported by the entry point lib.d.ts
-// Warning: (ae-forgotten-export) The symbol "__VLS_WithDefaults" needs to be exported by the entry point lib.d.ts
-// Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
-//
 // @public (undocumented)
-export const STable: __VLS_WithTemplateSlots_28<DefineComponent<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
-data?: TableRow[] | undefined;
-defaultSort?: {
+export const STable: <DataType extends TableRow>(__VLS_props: {
+    data?: DataType[] | undefined;
+    onSelect?: ((args_0: DataType[], args_1: DataType) => any) | undefined;
+    height?: string | number | undefined;
+    maxHeight?: string | number | undefined;
+    "onMouse-enter:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+    "onMouse-leave:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+    "onClick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+    "onDblclick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+    "onClick:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+    "onContextmenu:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+    "onClick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+    "onDblclick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+    "onContextmenu:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+    "onChange:sort"?: ((value: TableSortEventData) => any) | undefined;
+    "onChange:selection"?: ((value: DataType[]) => any) | undefined;
+    "onSelect-all"?: ((value: DataType[]) => any) | undefined;
+    "onChange:expand"?: ((args_0: DataType, args_1: DataType[]) => any) | undefined;
+    "onChange:current"?: ((args_0: DataType | null, args_1: DataType | null) => any) | undefined;
+    "onClick:row-details"?: ((value: DataType) => any) | undefined;
+    defaultSort?: {
+        prop: string;
+        order: TableColumnSortOrder;
+    } | null | undefined;
+    fit?: boolean | undefined;
+    showHeader?: boolean | undefined;
+    highlightCurrentRow?: boolean | undefined;
+    currentRowKey?: string | number | undefined;
+    rowClassName?: string | ((param: TableRowConfigCallbackParams) => string) | undefined;
+    rowStyle?: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+    cellClassName?: string | ((param: TableCellConfigCallbackParams) => string) | undefined;
+    cellStyle?: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+    headerRowClassName?: string | (() => string) | undefined;
+    headerRowStyle?: Partial<CSSProperties> | (() => Partial<CSSProperties>) | undefined;
+    headerCellClassName?: string | ((param: TableHeaderCellConfigCallbackParams) => string) | undefined;
+    headerCellStyle?: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+    rowKey?: string | ((row: DataType) => unknown) | null | undefined;
+    emptyText?: string | undefined;
+    defaultExpandAll?: boolean | undefined;
+    expandRowKeys?: unknown[] | undefined;
+    selectOnIndeterminate?: boolean | undefined;
+    adaptBreakpoint?: number | undefined;
+    cardGridBreakpoints?: TableCardGridBreakpoint[] | undefined;
+} & VNodeProps & AllowedComponentProps & ComponentCustomProps, __VLS_ctx?: {
+    attrs: any;
+    slots: {
+        empty?(_: {}): any;
+        "empty-text"?(_: {}): any;
+        append?(_: {}): any;
+        default?(_: {}): any;
+    };
+    emit: {
+        (event: 'mouse-enter:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'mouse-leave:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'click:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'dblclick:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'click:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+        (event: 'contextmenu:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+        (event: 'click:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'dblclick:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'contextmenu:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'change:sort', value: TableSortEventData): void;
+        (event: 'change:selection', value: DataType[]): void;
+        (event: 'select-all', value: DataType[]): void;
+        (event: 'select', value_0: DataType[], value_1: DataType): void;
+        (event: 'change:expand', value_0: DataType, value_1: DataType[]): void;
+        (event: 'change:current', value_0: DataType | null, value_1: DataType | null): void;
+        (event: 'click:row-details', value: DataType): void;
+    };
+} | undefined, __VLS_expose?: ((exposed: ShallowUnwrapRef<    {
+clearSelection: () => void;
+toggleRowSelection: (row: DataType, value?: boolean) => void;
+toggleAllSelection: () => void;
+toggleRowExpansion: (row: DataType, value?: boolean | undefined) => void;
+sort: ({ prop, order }: {
 prop: string;
 order: TableColumnSortOrder;
-} | null | undefined;
-height?: string | number | undefined;
-maxHeight?: string | number | undefined;
-fit?: boolean | undefined;
-showHeader?: boolean | undefined;
-highlightCurrentRow?: boolean | undefined;
-currentRowKey?: string | number | undefined;
-rowClassName?: string | ((param: TableRowConfigCallbackParams) => string) | undefined;
-rowStyle?: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-cellClassName?: string | ((param: TableCellConfigCallbackParams) => string) | undefined;
-cellStyle?: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-headerRowClassName?: string | (() => string) | undefined;
-headerRowStyle?: Partial<CSSProperties> | (() => Partial<CSSProperties>) | undefined;
-headerCellClassName?: string | ((param: TableHeaderCellConfigCallbackParams) => string) | undefined;
-headerCellStyle?: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-rowKey?: string | ((row: TableRow) => unknown) | null | undefined;
-emptyText?: string | undefined;
-defaultExpandAll?: boolean | undefined;
-expandRowKeys?: unknown[] | undefined;
-selectOnIndeterminate?: boolean | undefined;
-adaptBreakpoint?: number | undefined;
-cardGridBreakpoints?: TableCardGridBreakpoint[] | undefined;
-}>, {
-data: () => never[];
-defaultSort: null;
-height: string;
-maxHeight: string;
-emptyText: string;
-defaultExpandAll: boolean;
-rowKey: null;
-fit: boolean;
-expandRowKeys: () => never[];
-showHeader: boolean;
-rowClassName: string;
-rowStyle: () => {};
-cellClassName: string;
-cellStyle: () => {};
-headerRowClassName: string;
-headerRowStyle: () => {};
-headerCellClassName: string;
-headerCellStyle: () => {};
-selectOnIndeterminate: boolean;
-highlightCurrentRow: boolean;
-currentRowKey: string;
-adaptBreakpoint: number;
-cardGridBreakpoints: () => {
-test: (width: number) => boolean;
-value: number;
-}[];
-}>, {
-clearSelection: typeof manualClearSelection;
-toggleRowSelection: typeof manualToggleRowSelection;
-toggleAllSelection: typeof manualToggleAllSelection;
-toggleRowExpansion: (row: TableRow, value?: boolean | undefined) => void;
-sort: typeof sort;
+}) => void;
 clearSort: () => void;
-setCurrentRow: typeof setCurrentRow;
-}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
-"mouse-enter:cell": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => void;
-"mouse-leave:cell": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => void;
-"click:cell": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => void;
-"dblclick:cell": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => void;
-"click:header": (args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => void;
-"contextmenu:header": (args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => void;
-"click:row": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => void;
-"dblclick:row": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => void;
-"contextmenu:row": (args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => void;
-"change:sort": (value: TableSortEventData) => void;
-"change:selection": (value: TableRow[]) => void;
-"select-all": (value: TableRow[]) => void;
-select: (args_0: TableRow[], args_1: TableRow) => void;
-"change:expand": (args_0: TableRow, args_1: TableRow[]) => void;
-"change:current": (args_0: TableRow | null, args_1: TableRow | null) => void;
-"click:row-details": (value: TableRow) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_WithDefaults_26<__VLS_TypePropsToRuntimeProps_29<{
-data?: TableRow[] | undefined;
-defaultSort?: {
-prop: string;
-order: TableColumnSortOrder;
-} | null | undefined;
-height?: string | number | undefined;
-maxHeight?: string | number | undefined;
-fit?: boolean | undefined;
-showHeader?: boolean | undefined;
-highlightCurrentRow?: boolean | undefined;
-currentRowKey?: string | number | undefined;
-rowClassName?: string | ((param: TableRowConfigCallbackParams) => string) | undefined;
-rowStyle?: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-cellClassName?: string | ((param: TableCellConfigCallbackParams) => string) | undefined;
-cellStyle?: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-headerRowClassName?: string | (() => string) | undefined;
-headerRowStyle?: Partial<CSSProperties> | (() => Partial<CSSProperties>) | undefined;
-headerCellClassName?: string | ((param: TableHeaderCellConfigCallbackParams) => string) | undefined;
-headerCellStyle?: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
-rowKey?: string | ((row: TableRow) => unknown) | null | undefined;
-emptyText?: string | undefined;
-defaultExpandAll?: boolean | undefined;
-expandRowKeys?: unknown[] | undefined;
-selectOnIndeterminate?: boolean | undefined;
-adaptBreakpoint?: number | undefined;
-cardGridBreakpoints?: TableCardGridBreakpoint[] | undefined;
-}>, {
-data: () => never[];
-defaultSort: null;
-height: string;
-maxHeight: string;
-emptyText: string;
-defaultExpandAll: boolean;
-rowKey: null;
-fit: boolean;
-expandRowKeys: () => never[];
-showHeader: boolean;
-rowClassName: string;
-rowStyle: () => {};
-cellClassName: string;
-cellStyle: () => {};
-headerRowClassName: string;
-headerRowStyle: () => {};
-headerCellClassName: string;
-headerCellStyle: () => {};
-selectOnIndeterminate: boolean;
-highlightCurrentRow: boolean;
-currentRowKey: string;
-adaptBreakpoint: number;
-cardGridBreakpoints: () => {
-test: (width: number) => boolean;
-value: number;
-}[];
-}>>> & {
-onSelect?: ((args_0: TableRow[], args_1: TableRow) => any) | undefined;
-"onMouse-enter:cell"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
-"onMouse-leave:cell"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
-"onClick:cell"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
-"onDblclick:cell"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
-"onClick:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
-"onContextmenu:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
-"onClick:row"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
-"onDblclick:row"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
-"onContextmenu:row"?: ((args_0: TableRow, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
-"onChange:sort"?: ((value: TableSortEventData) => any) | undefined;
-"onChange:selection"?: ((value: TableRow[]) => any) | undefined;
-"onSelect-all"?: ((value: TableRow[]) => any) | undefined;
-"onChange:expand"?: ((args_0: TableRow, args_1: TableRow[]) => any) | undefined;
-"onChange:current"?: ((args_0: TableRow | null, args_1: TableRow | null) => any) | undefined;
-"onClick:row-details"?: ((value: TableRow) => any) | undefined;
-}, {
-data: TableRow[];
-height: string | number;
-maxHeight: string | number;
-defaultSort: {
-prop: string;
-order: TableColumnSortOrder;
-} | null;
-fit: boolean;
-showHeader: boolean;
-highlightCurrentRow: boolean;
-currentRowKey: string | number;
-rowClassName: string | ((param: TableRowConfigCallbackParams) => string);
-rowStyle: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>);
-cellClassName: string | ((param: TableCellConfigCallbackParams) => string);
-cellStyle: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>);
-headerRowClassName: string | (() => string);
-headerRowStyle: Partial<CSSProperties> | (() => Partial<CSSProperties>);
-headerCellClassName: string | ((param: TableHeaderCellConfigCallbackParams) => string);
-headerCellStyle: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>);
-rowKey: string | ((row: TableRow) => unknown) | null;
-emptyText: string;
-defaultExpandAll: boolean;
-expandRowKeys: unknown[];
-selectOnIndeterminate: boolean;
-adaptBreakpoint: number;
-cardGridBreakpoints: TableCardGridBreakpoint[];
-}, {}>, {
-    empty?(_: {}): any;
-    "empty-text"?(_: {}): any;
-    append?(_: {}): any;
-    default?(_: {}): any;
-}>;
+setCurrentRow: (row: DataType | null) => void;
+}>) => void) | undefined, __VLS_setup?: Promise<{
+    props: {
+        data?: DataType[] | undefined;
+        onSelect?: ((args_0: DataType[], args_1: DataType) => any) | undefined;
+        height?: string | number | undefined;
+        maxHeight?: string | number | undefined;
+        "onMouse-enter:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+        "onMouse-leave:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+        "onClick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+        "onDblclick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+        "onClick:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+        "onContextmenu:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+        "onClick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+        "onDblclick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+        "onContextmenu:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+        "onChange:sort"?: ((value: TableSortEventData) => any) | undefined;
+        "onChange:selection"?: ((value: DataType[]) => any) | undefined;
+        "onSelect-all"?: ((value: DataType[]) => any) | undefined;
+        "onChange:expand"?: ((args_0: DataType, args_1: DataType[]) => any) | undefined;
+        "onChange:current"?: ((args_0: DataType | null, args_1: DataType | null) => any) | undefined;
+        "onClick:row-details"?: ((value: DataType) => any) | undefined;
+        defaultSort?: {
+            prop: string;
+            order: TableColumnSortOrder;
+        } | null | undefined;
+        fit?: boolean | undefined;
+        showHeader?: boolean | undefined;
+        highlightCurrentRow?: boolean | undefined;
+        currentRowKey?: string | number | undefined;
+        rowClassName?: string | ((param: TableRowConfigCallbackParams) => string) | undefined;
+        rowStyle?: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+        cellClassName?: string | ((param: TableCellConfigCallbackParams) => string) | undefined;
+        cellStyle?: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+        headerRowClassName?: string | (() => string) | undefined;
+        headerRowStyle?: Partial<CSSProperties> | (() => Partial<CSSProperties>) | undefined;
+        headerCellClassName?: string | ((param: TableHeaderCellConfigCallbackParams) => string) | undefined;
+        headerCellStyle?: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+        rowKey?: string | ((row: DataType) => unknown) | null | undefined;
+        emptyText?: string | undefined;
+        defaultExpandAll?: boolean | undefined;
+        expandRowKeys?: unknown[] | undefined;
+        selectOnIndeterminate?: boolean | undefined;
+        adaptBreakpoint?: number | undefined;
+        cardGridBreakpoints?: TableCardGridBreakpoint[] | undefined;
+    } & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+    expose(exposed: ShallowUnwrapRef<    {
+    clearSelection: () => void;
+    toggleRowSelection: (row: DataType, value?: boolean) => void;
+    toggleAllSelection: () => void;
+    toggleRowExpansion: (row: DataType, value?: boolean | undefined) => void;
+    sort: ({ prop, order }: {
+    prop: string;
+    order: TableColumnSortOrder;
+    }) => void;
+    clearSort: () => void;
+    setCurrentRow: (row: DataType | null) => void;
+    }>): void;
+    attrs: any;
+    slots: {
+        empty?(_: {}): any;
+        "empty-text"?(_: {}): any;
+        append?(_: {}): any;
+        default?(_: {}): any;
+    };
+    emit: {
+        (event: 'mouse-enter:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'mouse-leave:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'click:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'dblclick:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+        (event: 'click:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+        (event: 'contextmenu:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+        (event: 'click:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'dblclick:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'contextmenu:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+        (event: 'change:sort', value: TableSortEventData): void;
+        (event: 'change:selection', value: DataType[]): void;
+        (event: 'select-all', value: DataType[]): void;
+        (event: 'select', value_0: DataType[], value_1: DataType): void;
+        (event: 'change:expand', value_0: DataType, value_1: DataType[]): void;
+        (event: 'change:current', value_0: DataType | null, value_1: DataType | null): void;
+        (event: 'click:row-details', value: DataType): void;
+    };
+}>) => globalThis.VNode<RendererNode, RendererElement, {
+    [key: string]: any;
+}> & {
+    __ctx?: {
+        props: {
+            data?: DataType[] | undefined;
+            onSelect?: ((args_0: DataType[], args_1: DataType) => any) | undefined;
+            height?: string | number | undefined;
+            maxHeight?: string | number | undefined;
+            "onMouse-enter:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+            "onMouse-leave:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+            "onClick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+            "onDblclick:cell"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: EventTarget, args_3: MouseEvent) => any) | undefined;
+            "onClick:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+            "onContextmenu:header"?: ((args_0: TableColumnApi | TableActionColumnApi, args_1: MouseEvent) => any) | undefined;
+            "onClick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+            "onDblclick:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+            "onContextmenu:row"?: ((args_0: DataType, args_1: TableColumnApi | TableActionColumnApi, args_2: MouseEvent) => any) | undefined;
+            "onChange:sort"?: ((value: TableSortEventData) => any) | undefined;
+            "onChange:selection"?: ((value: DataType[]) => any) | undefined;
+            "onSelect-all"?: ((value: DataType[]) => any) | undefined;
+            "onChange:expand"?: ((args_0: DataType, args_1: DataType[]) => any) | undefined;
+            "onChange:current"?: ((args_0: DataType | null, args_1: DataType | null) => any) | undefined;
+            "onClick:row-details"?: ((value: DataType) => any) | undefined;
+            defaultSort?: {
+                prop: string;
+                order: TableColumnSortOrder;
+            } | null | undefined;
+            fit?: boolean | undefined;
+            showHeader?: boolean | undefined;
+            highlightCurrentRow?: boolean | undefined;
+            currentRowKey?: string | number | undefined;
+            rowClassName?: string | ((param: TableRowConfigCallbackParams) => string) | undefined;
+            rowStyle?: Partial<CSSProperties> | ((param: TableRowConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+            cellClassName?: string | ((param: TableCellConfigCallbackParams) => string) | undefined;
+            cellStyle?: Partial<CSSProperties> | ((param: TableCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+            headerRowClassName?: string | (() => string) | undefined;
+            headerRowStyle?: Partial<CSSProperties> | (() => Partial<CSSProperties>) | undefined;
+            headerCellClassName?: string | ((param: TableHeaderCellConfigCallbackParams) => string) | undefined;
+            headerCellStyle?: Partial<CSSProperties> | ((param: TableHeaderCellConfigCallbackParams) => Partial<CSSProperties>) | undefined;
+            rowKey?: string | ((row: DataType) => unknown) | null | undefined;
+            emptyText?: string | undefined;
+            defaultExpandAll?: boolean | undefined;
+            expandRowKeys?: unknown[] | undefined;
+            selectOnIndeterminate?: boolean | undefined;
+            adaptBreakpoint?: number | undefined;
+            cardGridBreakpoints?: TableCardGridBreakpoint[] | undefined;
+        } & VNodeProps & AllowedComponentProps & ComponentCustomProps;
+        expose(exposed: ShallowUnwrapRef<    {
+        clearSelection: () => void;
+        toggleRowSelection: (row: DataType, value?: boolean) => void;
+        toggleAllSelection: () => void;
+        toggleRowExpansion: (row: DataType, value?: boolean | undefined) => void;
+        sort: ({ prop, order }: {
+        prop: string;
+        order: TableColumnSortOrder;
+        }) => void;
+        clearSort: () => void;
+        setCurrentRow: (row: DataType | null) => void;
+        }>): void;
+        attrs: any;
+        slots: {
+            empty?(_: {}): any;
+            "empty-text"?(_: {}): any;
+            append?(_: {}): any;
+            default?(_: {}): any;
+        };
+        emit: {
+            (event: 'mouse-enter:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+            (event: 'mouse-leave:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+            (event: 'click:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+            (event: 'dblclick:cell', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: EventTarget, value_3: MouseEvent): void;
+            (event: 'click:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+            (event: 'contextmenu:header', value_0: TableColumnApi | TableActionColumnApi, value_1: MouseEvent): void;
+            (event: 'click:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+            (event: 'dblclick:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+            (event: 'contextmenu:row', value_0: DataType, value_1: TableColumnApi | TableActionColumnApi, value_2: MouseEvent): void;
+            (event: 'change:sort', value: TableSortEventData): void;
+            (event: 'change:selection', value: DataType[]): void;
+            (event: 'select-all', value: DataType[]): void;
+            (event: 'select', value_0: DataType[], value_1: DataType): void;
+            (event: 'change:expand', value_0: DataType, value_1: DataType[]): void;
+            (event: 'change:current', value_0: DataType | null, value_1: DataType | null): void;
+            (event: 'click:row-details', value: DataType): void;
+        };
+    } | undefined;
+};
 
 // @public (undocumented)
 export const STableColumn: DefineComponent<    {
@@ -2084,7 +2147,7 @@ apiKey: ProvideKey | ProvideKey[];
 // Warning: (ae-forgotten-export) The symbol "__VLS_TypePropsToRuntimeProps" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)
-export const STooltip: __VLS_WithTemplateSlots_30<DefineComponent<__VLS_WithDefaults_28<__VLS_TypePropsToRuntimeProps_31<{
+export const STooltip: __VLS_WithTemplateSlots_29<DefineComponent<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
 wrapperTag?: string | object | undefined;
 content?: string | undefined;
 header?: string | undefined;
@@ -2101,7 +2164,7 @@ secondaryButtonText: string;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
 "click:primary-button": (...args: any[]) => void;
 "click:secondary-button": (...args: any[]) => void;
-}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_WithDefaults_28<__VLS_TypePropsToRuntimeProps_31<{
+}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_WithDefaults_27<__VLS_TypePropsToRuntimeProps_30<{
 wrapperTag?: string | object | undefined;
 content?: string | undefined;
 header?: string | undefined;
@@ -2220,7 +2283,7 @@ export interface TableCellConfigCallbackParams {
 }
 
 // @public (undocumented)
-export type TableCellEventData = [TableRow, TableColumnApi | TableActionColumnApi, EventTarget, MouseEvent];
+export type TableCellEventData<T extends TableRow> = [T, TableColumnApi | TableActionColumnApi, EventTarget, MouseEvent];
 
 // @public (undocumented)
 export type TableColumnAlign = typeof TABLE_COLUMN_ALIGN_VALUES[number];
@@ -2326,7 +2389,7 @@ export interface TableRowConfigCallbackParams {
 }
 
 // @public (undocumented)
-export type TableRowEventData = [TableRow, TableColumnApi | TableActionColumnApi, MouseEvent];
+export type TableRowEventData<T extends TableRow> = [T, TableColumnApi | TableActionColumnApi, MouseEvent];
 
 // @public (undocumented)
 export interface TableSortEventData {
@@ -2435,11 +2498,6 @@ export function useTabsPanelApi(): TabsPanelApi;
 
 // Warnings were encountered during analysis:
 //
-// dist-ts/components/Table/STable.vue.d.ts:149:5 - (ae-forgotten-export) The symbol "manualClearSelection" needs to be exported by the entry point lib.d.ts
-// dist-ts/components/Table/STable.vue.d.ts:154:5 - (ae-forgotten-export) The symbol "manualToggleRowSelection" needs to be exported by the entry point lib.d.ts
-// dist-ts/components/Table/STable.vue.d.ts:158:5 - (ae-forgotten-export) The symbol "manualToggleAllSelection" needs to be exported by the entry point lib.d.ts
-// dist-ts/components/Table/STable.vue.d.ts:167:5 - (ae-forgotten-export) The symbol "sort" needs to be exported by the entry point lib.d.ts
-// dist-ts/components/Table/STable.vue.d.ts:176:5 - (ae-forgotten-export) The symbol "setCurrentRow" needs to be exported by the entry point lib.d.ts
 // dist-ts/components/Toasts/SToastsDisplay.vue.d.ts:9:9 - (ae-forgotten-export) The symbol "validateVerticalPlacement" needs to be exported by the entry point lib.d.ts
 // dist-ts/components/Toasts/SToastsDisplay.vue.d.ts:14:9 - (ae-forgotten-export) The symbol "validateHorizontalPlacement" needs to be exported by the entry point lib.d.ts
 // dist-ts/components/Toasts/SToastsProvider.d.ts:11:9 - (ae-forgotten-export) The symbol "ProvideKey" needs to be exported by the entry point lib.d.ts

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu-ui/ui",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "main": "dist/lib.cjs",
   "module": "dist/lib.mjs",
   "types": "dist/lib.d.ts",

--- a/packages/ui/src/components/Table/STableCard.vue
+++ b/packages/ui/src/components/Table/STableCard.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+<script setup lang="ts" generic="DataType extends TableRow">
 import type { TableActionColumnApi, TableColumnApi, TableRow } from '@/components'
 import { IconArrowsChevronDownRounded24, IconArrowRight16 } from '@/components/icons'
 import {
@@ -13,7 +13,7 @@ import SButton from '@/components/Button/SButton.vue'
 
 const props = withDefaults(
   defineProps<{
-    row: { data: TableRow; index: number }
+    row: { data: DataType; index: number }
     columns?: (TableColumnApi | TableActionColumnApi)[]
     activeExpandColumn?: (TableActionColumnApi & { type: 'expand' }) | null
     expanded?: boolean
@@ -37,7 +37,7 @@ const emit = defineEmits<{
   (event: 'mouse-event:label', value: { column: TableColumnApi | TableActionColumnApi; event: MouseEvent }): void
   (
     event: 'mouse-event:value',
-    value: { row: TableRow; column: TableColumnApi | TableActionColumnApi; event: MouseEvent },
+    value: { row: DataType; column: TableColumnApi | TableActionColumnApi; event: MouseEvent },
   ): void
 }>()
 

--- a/packages/ui/src/components/Table/types.ts
+++ b/packages/ui/src/components/Table/types.ts
@@ -6,8 +6,8 @@ export type TableColumnAlign = typeof TABLE_COLUMN_ALIGN_VALUES[number]
 
 export type TableRow = Record<string, unknown>
 
-export type TableCellEventData = [TableRow, TableColumnApi | TableActionColumnApi, EventTarget, MouseEvent]
-export type TableRowEventData = [TableRow, TableColumnApi | TableActionColumnApi, MouseEvent]
+export type TableCellEventData<T extends TableRow> = [T, TableColumnApi | TableActionColumnApi, EventTarget, MouseEvent]
+export type TableRowEventData<T extends TableRow> = [T, TableColumnApi | TableActionColumnApi, MouseEvent]
 export type TableHeaderEventData = [TableColumnApi | TableActionColumnApi, MouseEvent]
 export interface TableSortEventData {
   column: TableColumnApi

--- a/packages/ui/src/components/Table/use-column-expand.ts
+++ b/packages/ui/src/components/Table/use-column-expand.ts
@@ -1,9 +1,9 @@
 import type { TableRow } from '@/components/Table/types'
 
-export function useColumnExpand() {
-  const expandedRows = shallowReactive(new Set<TableRow>())
+export function useColumnExpand<T extends TableRow>() {
+  const expandedRows = shallowReactive(new Set<T>())
 
-  function toggleRowExpanded(row: TableRow, value?: boolean) {
+  function toggleRowExpanded(row: T, value?: boolean) {
     if ((value !== undefined && !value) || (value === undefined && expandedRows.has(row))) {
       expandedRows.delete(row)
 

--- a/packages/ui/src/components/Table/use-column-sort.ts
+++ b/packages/ui/src/components/Table/use-column-sort.ts
@@ -1,14 +1,14 @@
-import type { Ref } from 'vue'
+import type { Ref, ShallowRef } from 'vue'
 import type { TableColumnApi } from './api'
 import type { TableColumnSortOrder, TableRow } from './types'
 import { get } from 'lodash-es'
 
-export function useColumnSort(data: Ref<TableRow[]>) {
+export function useColumnSort<T extends TableRow>(data: Ref<T[]>) {
   const sortState: { column: TableColumnApi | null; order: TableColumnSortOrder } = shallowReactive({
     column: null,
     order: null,
   })
-  let sortedData: Ref<TableRow[]> = ref(data.value)
+  let sortedData: ShallowRef<T[]> = shallowRef(data.value)
 
   function startSortWithNewColumn(column: TableColumnApi | null) {
     sortState.column = column

--- a/packages/ui/src/components/Table/use-row-select.ts
+++ b/packages/ui/src/components/Table/use-row-select.ts
@@ -1,8 +1,8 @@
 import type { Ref } from 'vue'
 import type { TableColumnRowSelectableFunc, TableRow } from './types'
 
-export function useRowSelect(data: Ref<TableRow[]>, options: { selectOnIndeterminate: boolean }) {
-  const selectedRows = shallowReactive(new Set<TableRow>())
+export function useRowSelect<T extends TableRow>(data: Ref<T[]>, options: { selectOnIndeterminate: boolean }) {
+  const selectedRows = shallowReactive(new Set<T>())
   const isAllSelected = computed(() => selectedRows.size === data.value.length)
   const isSomeSelected = computed(() => selectedRows.size > 0)
 
@@ -32,7 +32,7 @@ export function useRowSelect(data: Ref<TableRow[]>, options: { selectOnIndetermi
     }
   }
 
-  function toggleRowSelection(row: TableRow, value?: boolean) {
+  function toggleRowSelection(row: T, value?: boolean) {
     if ((value !== undefined && !value) || (value === undefined && selectedRows.has(row))) {
       selectedRows.delete(row)
 


### PR DESCRIPTION
#545 

Now value will be the same type as provided data instead of TableRow. Example with one of the events:
<img width="627" alt="Снимок экрана 2024-06-14 в 15 25 31" src="https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/c13b6f8c-9fe1-4962-8852-2a06c1c60057">

For future : somehow we have to provide generics for `formatter` property in STableColumn component.