### PR TITLE
Fix - Add classes for s-modal div

### DIFF
--- a/.changeset/kind-experts-attend.md
+++ b/.changeset/kind-experts-attend.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**refactor**: update vue-tsc and ts and fix everything updated version breaks

--- a/.changeset/purple-bananas-flow.md
+++ b/.changeset/purple-bananas-flow.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`SModalCard`): add `s-modal-card__content` class and apply windicss classes

--- a/.changeset/purple-bananas-flow.md
+++ b/.changeset/purple-bananas-flow.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**fix**(`SModalCard`): add `s-modal-card__content` class and apply windicss classes

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @soramitsu-ui/ui
 
+## 0.13.7
+
+### Patch Changes
+
+- 2d62a77c: **fix**(`SModalCard`): add `s-modal-card__content` class and apply windicss classes
+- 75066428: **refactor**: update vue-tsc and ts and fix everything updated version breaks
+
 ## 0.13.6
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu-ui/ui",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "main": "dist/lib.cjs",
   "module": "dist/lib.mjs",
   "types": "dist/lib.d.ts",

--- a/packages/ui/src/components/Modal/SModalCard.vue
+++ b/packages/ui/src/components/Modal/SModalCard.vue
@@ -54,7 +54,7 @@ function closeClick() {
       </SButton>
     </div>
 
-    <div class="px-6 py-8">
+    <div class="s-modal-card__content px-6 py-8 flex flex-col flex-grow min-h-0">
       <slot />
     </div>
   </div>

--- a/packages/ui/stories/components/Modal.stories.ts
+++ b/packages/ui/stories/components/Modal.stories.ts
@@ -1,7 +1,7 @@
 import { SModalCard, SModal, SButton } from '@/lib'
-import type { Meta } from '@storybook/vue3'
+import type { Meta, StoryObj } from '@storybook/vue3'
 
-export default {
+const meta = {
   component: defineComponent({
     components: {
       SModal,
@@ -23,27 +23,26 @@ export default {
       <SButton @click="show = true">
         Show modal
       </SButton>
-  
-      <SModal v-model:show="show" v-bind="$attrs">
-        <SModalCard>
+
+      <SModal
+          v-model:show="show"
+          v-bind="$attrs"
+      >
+        <SModalCard class="flex flex-col max-h-90vh">
           <template #title>
             Modal <i>title</i>
           </template>
-          
-          <div class="space-y-4">
 
+          <div class="space-y-4 overflow-auto">
+            <p :class="{ 'h-800px': $attrs.bigContentHeight }">
+              Pay attention to focus trap! (button is focused!)
+            </p>
 
-          <p>
-            Pay attention to focus trap! (button is focused!)
-          </p>
+            <p>Counter (eagerness check): <Counter /></p>
 
-          <p>
-            Counter (eagerness check): <Counter />
-          </p>
-
-          <SButton @click="show = false">
-            Close
-          </SButton>
+            <SButton @click="show = false">
+              Close
+            </SButton>
           </div>
         </SModalCard>
       </SModal>
@@ -57,4 +56,10 @@ export default {
   },
 } as Meta
 
+type Story = StoryObj<typeof meta>
+
+export default meta
+
 export const Default = {}
+
+export const BigContentHeight = { args: { bigContentHeight: true } } as Story


### PR DESCRIPTION
Without following styles div containing slot in s-modal-card component won't scroll so we have to add these styles every time.
```
& > div:last-child {
    display: flex;
    flex-grow: 1;
    flex-direction: column;
    min-height: 0;
  }
```

I've also added s-modal-card__content class so it will be easier to apply styles to that div.