### PR TITLE
Feature - Add prop to limit s dropdown height

### DIFF
--- a/.changeset/wet-horses-hope.md
+++ b/.changeset/wet-horses-hope.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**feat**(`SSelectDropdown`): add `maxShownOptions` prop

--- a/.changeset/wet-horses-hope.md
+++ b/.changeset/wet-horses-hope.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**feat**(`SSelectDropdown`): add `maxShownOptions` prop

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @soramitsu-ui/ui
 
+## 0.13.8
+
+### Patch Changes
+
+- d7228159: **feat**(`SSelectDropdown`): add `maxShownOptions` prop
+
 ## 0.13.7
 
 ### Patch Changes

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -645,7 +645,7 @@ noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
-maxShownOptions?: number | undefined;
+maxShownOptions?: string | number | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_TypePropsToRuntimeProps_10<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -659,7 +659,7 @@ noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
-maxShownOptions?: number | undefined;
+maxShownOptions?: string | number | undefined;
 }>>>, {}, {}>, {
     label?(_: {
         options: UnwrapRef<SelectOption<any>[] | SelectOptionGroup<any>[]>;
@@ -1281,7 +1281,7 @@ loading?: boolean | undefined;
 triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
-maxShownOptions?: number | undefined;
+maxShownOptions?: string | number | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_TypePropsToRuntimeProps_9<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -1295,7 +1295,7 @@ loading?: boolean | undefined;
 triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
-maxShownOptions?: number | undefined;
+maxShownOptions?: string | number | undefined;
 }>>>, {}, {}>, {
     label?(_: {
         options: UnwrapRef<SelectOption<any>[] | SelectOptionGroup<any>[]>;

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -645,6 +645,7 @@ noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
+maxShownOptions?: number | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_TypePropsToRuntimeProps_10<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -658,6 +659,7 @@ noAutoClose?: boolean | undefined;
 loading?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
+maxShownOptions?: number | undefined;
 }>>>, {}, {}>, {
     label?(_: {
         options: UnwrapRef<SelectOption<any>[] | SelectOptionGroup<any>[]>;

--- a/packages/ui/etc/api/ui.api.md
+++ b/packages/ui/etc/api/ui.api.md
@@ -1281,6 +1281,7 @@ loading?: boolean | undefined;
 triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
+maxShownOptions?: number | undefined;
 }>, {}, unknown, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {}, string, VNodeProps & AllowedComponentProps & ComponentCustomProps, Readonly<globalThis.ExtractPropTypes<__VLS_TypePropsToRuntimeProps_9<{
 modelValue?: any;
 options?: SelectOption<any>[] | SelectOptionGroup<any>[] | undefined;
@@ -1294,6 +1295,7 @@ loading?: boolean | undefined;
 triggerSearch?: boolean | undefined;
 dropdownSearch?: boolean | undefined;
 remoteSearch?: boolean | undefined;
+maxShownOptions?: number | undefined;
 }>>>, {}, {}>, {
     label?(_: {
         options: UnwrapRef<SelectOption<any>[] | SelectOptionGroup<any>[]>;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu-ui/ui",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "main": "dist/lib.cjs",
   "module": "dist/lib.mjs",
   "types": "dist/lib.d.ts",

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -31,7 +31,10 @@ function isThereLabelSlot() {
 </script>
 
 <template>
-  <SSelectBase v-bind="{ ...$attrs, ...$props } as any">
+  <SSelectBase
+    v-bind="{ ...$attrs, ...$props } as any"
+    same-width-popper
+  >
     <template #control>
       <SSelectButton
         data-testid="select-trigger"

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   loading?: boolean
   dropdownSearch?: boolean
   remoteSearch?: boolean
+  maxShownOptions?: number | undefined
 }>()
 
 const buttonType = computed(() => (props.inline ? SelectButtonType.Inline : SelectButtonType.Default))
@@ -54,6 +55,7 @@ function isThereLabelSlot() {
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? SelectOptionType.Default"
+        :max-shown-options="maxShownOptions"
       >
         <template #empty>
           <slot name="empty" />

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   loading?: boolean
   dropdownSearch?: boolean
   remoteSearch?: boolean
-  maxShownOptions?: number | undefined
+  maxShownOptions?: string | number | undefined
 }>()
 
 const buttonType = computed(() => (props.inline ? SelectButtonType.Inline : SelectButtonType.Default))
@@ -58,7 +58,7 @@ function isThereLabelSlot() {
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? SelectOptionType.Default"
-        :max-shown-options="maxShownOptions"
+        :max-shown-options="+(maxShownOptions ?? 0)"
       >
         <template #empty>
           <slot name="empty" />

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   triggerSearch?: boolean
   dropdownSearch?: boolean
   remoteSearch?: boolean
+  maxShownOptions?: number | undefined
 }>()
 
 const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Checkbox : SelectOptionType.Radio))
@@ -48,6 +49,7 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? defaultOptionType"
+        :max-shown-options="maxShownOptions"
       >
         <template #empty>
           <slot name="empty" />

--- a/packages/ui/src/components/Select/SSelect.vue
+++ b/packages/ui/src/components/Select/SSelect.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   triggerSearch?: boolean
   dropdownSearch?: boolean
   remoteSearch?: boolean
-  maxShownOptions?: number | undefined
+  maxShownOptions?: string | number | undefined
 }>()
 
 const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Checkbox : SelectOptionType.Radio))
@@ -49,7 +49,7 @@ const defaultOptionType = computed(() => (props.multiple ? SelectOptionType.Chec
       <SSelectDropdown
         :search="search"
         :item-type="optionType ?? defaultOptionType"
-        :max-shown-options="maxShownOptions"
+        :max-shown-options="+(maxShownOptions ?? 0)"
       >
         <template #empty>
           <slot name="empty" />

--- a/packages/ui/src/components/Select/SSelectDropdown.vue
+++ b/packages/ui/src/components/Select/SSelectDropdown.vue
@@ -13,6 +13,7 @@ import type { MaybeElementRef } from '@vueuse/core'
 const props = defineProps<{
   itemType: SelectOptionType
   search: boolean
+  maxShownOptions?: number | undefined
 }>()
 
 const api = useSelectApi()
@@ -85,12 +86,26 @@ const SEARCH_ICON_SIZE = {
   [SelectSize.Md]: 16,
   [SelectSize.Sm]: 12,
 } as const
+
+const OPTION_SIZE = {
+  [SelectSize.Xl]: 56,
+  [SelectSize.Lg]: 40,
+  [SelectSize.Md]: 32,
+  [SelectSize.Sm]: 24,
+} as const
+
+const dropdownHeight = computed(() => {
+  if (!props.maxShownOptions) return
+
+  return OPTION_SIZE[api.size] * Math.min(props.maxShownOptions, api.options.length) + 'px'
+})
 </script>
 
 <template>
   <div
     class="s-select-dropdown"
     :class="`s-select-dropdown_size_${api.size}`"
+    :style="{ 'height': dropdownHeight ?? 'auto' }"
     data-testid="select-dropdown"
     @mousedown="handleMouseDown"
   >
@@ -178,6 +193,7 @@ const SEARCH_ICON_SIZE = {
 
 .s-select-dropdown {
   @apply rounded overflow-hidden;
+  overflow-y: auto;
   background: theme.token-as-var('sys.color.util.surface');
   box-shadow: theme.token-as-var('sys.shadow.dropdown');
 

--- a/packages/ui/stories/components/select/common.ts
+++ b/packages/ui/stories/components/select/common.ts
@@ -68,6 +68,7 @@ export const COMMON_ARGS = {
   label: 'Make a choice',
   noAutoClose: false,
   dropdownSearch: false,
+  maxShownOptions: 0,
 }
 
 export const COMMON_ARG_TYPES = {


### PR DESCRIPTION
#574 

Also I applied sameWidthPopper prop because without it SDropdown loading state would look like this
<img width="277" alt="Снимок экрана 2024-06-13 в 12 06 13" src="https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/7ef01b1b-defa-4ae1-ae48-a0634a71a871">

These commits aren't really organized because I had an issue with updating api.md file. Now it's resolved :)