### PR TITLE
Fix - Pagination page size dropdown

### DIFF
--- a/.changeset/serious-experts-serve.md
+++ b/.changeset/serious-experts-serve.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**fix**(`SDropdown`): add expression to display dropdown options correctly

--- a/.changeset/serious-experts-serve.md
+++ b/.changeset/serious-experts-serve.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**fix**(`SDropdown`): add expression to display dropdown options correctly

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @soramitsu-ui/ui
 
+## 0.13.11
+
+### Patch Changes
+
+- 0bc5daa2: **fix**(`SDropdown`): add expression to display dropdown options correctly
+
 ## 0.13.10
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu-ui/ui",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "main": "dist/lib.cjs",
   "module": "dist/lib.mjs",
   "types": "dist/lib.d.ts",

--- a/packages/ui/src/components/Select/SDropdown.vue
+++ b/packages/ui/src/components/Select/SDropdown.vue
@@ -33,7 +33,7 @@ function isThereLabelSlot() {
 <template>
   <SSelectBase
     v-bind="{ ...$attrs, ...$props } as any"
-    same-width-popper
+    :same-width-popper="loading"
   >
     <template #control>
       <SSelectButton


### PR DESCRIPTION
The aim of this pr is to fix such display
<img width="106" alt="Снимок экрана 2024-07-03 в 16 39 33" src="https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/000ca0b8-94ae-4d48-83d9-5e453ccaca7c">
But also prop should apply whenever loading is true to avoid the following display
<img width="292" alt="Снимок экрана 2024-07-03 в 16 41 49" src="https://github.com/soramitsu/soramitsu-js-ui-library/assets/149061523/ea36b677-dbec-42ab-93af-5579e657cc28">
