### PR TITLE
Feature - Display pointer cursor when hovering

### DIFF
--- a/.changeset/weak-hats-remember.md
+++ b/.changeset/weak-hats-remember.md
@@ -1,0 +1,5 @@
+---
+'@soramitsu-ui/ui': patch
+---
+
+**feat**(`STable`): change cursor style to pointer when hovering on a table row and handler for `click:row` event is truthy

--- a/.changeset/weak-hats-remember.md
+++ b/.changeset/weak-hats-remember.md
@@ -1,5 +1,0 @@
----
-'@soramitsu-ui/ui': patch
----
-
-**feat**(`STable`): change cursor style to pointer when hovering on a table row and handler for `click:row` event is truthy

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "prettier-eslint-cli": "^6.0.1",
     "typescript": "5.2.2",
     "vue-eslint-parser": "^9.3.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @soramitsu-ui/ui
 
+## 0.13.15
+
+### Patch Changes
+
+- 84b3cca6: **feat**(`STable`): change cursor style to pointer when hovering on a table row and handler for `click:row` event is truthy
+
 ## 0.13.14
 
 ### Patch Changes

--- a/packages/ui/cypress/component/STable.spec.cy.ts
+++ b/packages/ui/cypress/component/STable.spec.cy.ts
@@ -520,4 +520,48 @@ describe('Table', () => {
       })
     })
   })
+
+  context(`onClick:row`, () => {
+    beforeEach(() => {
+      cy.mount({
+        setup() {
+          const eventHandlerExistence = ref(true)
+
+          return {
+            data: DATA,
+            eventHandlerExistence,
+          }
+        },
+        template: `
+          <STable
+              v-if="eventHandlerExistence"
+              style="width: ${ADAPT_BREAKPOINT + 1}px"
+              :data="data"
+              @click:row="()=>{}"
+          >
+            <STableColumn/>
+          </STable>
+          <STable
+              v-else
+              style="width: ${ADAPT_BREAKPOINT + 1}px"
+              :data="data"
+          >
+            <STableColumn />
+          </STable>
+          
+        <button data-testid="toggle-handler" @click="eventHandlerExistence = false">Toggle</button>`,
+      })
+    })
+
+    context('When handler is attached', () => {
+      it('Then cursor should has pointer type', () => {
+        cy.get(testIdSelector('table-cell')).should('have.css', 'cursor', 'pointer')
+      })
+
+      it('Otherwise default', () => {
+        cy.get(testIdSelector('toggle-handler')).click()
+        cy.get(testIdSelector('table-cell')).should('have.css', 'cursor', 'default')
+      })
+    })
+  })
 })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soramitsu-ui/ui",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "main": "dist/lib.cjs",
   "module": "dist/lib.mjs",
   "types": "dist/lib.d.ts",

--- a/packages/ui/src/components/Table/STable.vue
+++ b/packages/ui/src/components/Table/STable.vue
@@ -583,6 +583,9 @@ function handleHeaderMouseEvent(ctx: { column: TableColumnApi | TableActionColum
     }
   }
 }
+
+const instance = getCurrentInstance()
+const hasClickRowHandler = computed(() => instance?.vnode?.props?.['onClick:row'])
 </script>
 
 <template>
@@ -730,6 +733,7 @@ function handleHeaderMouseEvent(ctx: { column: TableColumnApi | TableActionColum
                 :style="{
                   'width': rowIndex === 0 ? `${columnsWidths[columnIndex]}px` : '',
                   ...getStyleOrClass(cellStyle, { row, rowIndex, column, columnIndex }),
+                  'cursor': hasClickRowHandler ? 'pointer' : 'default',
                 }"
                 data-testid="table-cell"
                 @mouseenter="handleCellMouseEvent({ row, column, 'event': $event })"


### PR DESCRIPTION
When hovering on table row and handler for `click:row` event is being truthy cursor changes to pointer style. Otherwise it's default.